### PR TITLE
Check for mode flags, set Emulation Mode as default if no flags supplied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+QPULib.*
+tmp
+obj*
+.directory

--- a/Lib/VideoCore/SharedArray.h
+++ b/Lib/VideoCore/SharedArray.h
@@ -1,6 +1,16 @@
 #ifndef _SHAREDARRAY_H_
 #define _SHAREDARRAY_H_
 
+#if !defined(DEBUG_MODE) && !defined(EMULATION_MODE)
+//
+// Detect mode, set default if none defined.
+// This is the best place to test it in the code, since it's
+// the first of the header files to be compiled.
+//
+#pragma message "WARNING: DEBUG_MODE and EMULATION_MODE not defined, defaulting to EMULATION_MODE"
+#define EMULATION_MODE
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
At least one of the define's `DEBUG_MODE` and `EMULATION_MODE` must be set for the library compilation
This is a safeguard for giving an understandable warning when neither are set, and for sets a default.
Not doing this will otherwise result in strange compilation errors.

While the makefile adequately handles these define's, the code might change later on in which the given situation occurs.

As an extra, this commit adds a `.gitignore` to the project.