### PR TITLE
Add TODO.md to Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ QPULib.*
 tmp
 obj*
 .directory
+*.log

--- a/Doc/TODO.md
+++ b/Doc/TODO.md
@@ -1,7 +1,7 @@
 
 # TODO
 
-Feel free to add points here, or check them off if done.
+Feel free to add points here. If you complete a point, don't check it off, but remove it from the list.
 
 
 ## Makefile

--- a/Doc/TODO.md
+++ b/Doc/TODO.md
@@ -6,11 +6,6 @@ Feel free to add points here, or check them off if done.
 
 ## Makefile
 
-- [x] Raise the makefile one directory level and expand it
-- [x] Explanatory comment at top
-- [x] Static library for Lib-files
-- [x] Add include-file dependencies
-- [ ] Get rid of DEBUG option -> make debug output dynamic
 - [ ] Enable debug-build, for debugging
 - [ ] Add unit testing, notably `CATCH`
 - [ ] Add optional doc generation with `doxygen`
@@ -23,15 +18,15 @@ Feel free to add points here, or check them off if done.
   - [ ] 16-item vectors
   - [ ] Code Generation, not direct execution
 - [ ] Drill-down of the bare essentials for understanding `VideoCore`
-- [ ] 'Getting Started' to front page
 - [ ] Examples to separate page under Docs
 - [ ] Mailbox functions link to reference and explanation two size fields
 
 
 ## Unit Tests
 
-- [ ] Convert `AutoStart` to unit test
+- [ ] Convert `AutoTest` to unit test
 - [ ] Test same output for the various versions of `Rot3D`
+- [ ] Add test on expected source and target output for pretty print in `compileKernel`. E.g. for `Rot3D`, `Tri` and `HeatMap`.
 
 
 ### Unit testing for Debug
@@ -50,16 +45,21 @@ Feel free to add points here, or check them off if done.
 
 ## Investigate
 
-- [ ] Is the gather limit 8 or 4? This depends on threading being enabled, check code for this.
+- [ ] Is the gather limit 8 or 4? This depends on threading being enabled, check code for this
+- [ ] Find conclusive method to determine non-RPi platform. This to block compilation for QPU, see below
 
+
+## Library Code
+
+- [ ] output source and target code without having to recompile with `DEBUG=1`
+- [ ] Add check in emulator for too many `gather()` calls
+- [ ] Add namespace `qpulib` to Lib-files
+- [ ] Add method to determine RPi version via mailbox
 
 ## Other
 
-- [x] Add TODO to project
-- [ ] Add check in emulator for too many `gather()` calls
+- [ ] Rename directory `Tests` to `Examples`, issue #22
 - [ ] `Rot3D` make various versions selectable on command line
-- [ ] Add namespace `qpulib` to Lib-files
-- [ ] Add method to determine RPi version via mailbox
 - [ ] Prevent compile on non-RPi for `QPU=1`
 - [ ] enable `-Wall` on compilation and deal with all the fallout
 

--- a/Doc/TODO.md
+++ b/Doc/TODO.md
@@ -1,0 +1,93 @@
+
+# TODO
+
+Feel free to add points here, or check them off if done.
+
+
+## Makefile
+
+- [x] Raise the makefile one directory level and expand it
+- [x] Explanatory comment at top
+- [x] Static library for Lib-files
+- [ ] Add include-file dependencies
+- [ ] Get rid of DEBUG option -> make debug output dynamic
+- [ ] Enable debug-build, for debugging
+- [ ] Add unit testing, notably `CATCH`
+- [ ] Add optional doc generation with `doxygen`
+
+
+## Documentation
+
+- [ ] Document openGL issue on RPi 3
+- [ ] Explanation code
+  - [ ] 16-item vectors
+  - [ ] Code Generation, not direct execution
+- [ ] Drill-down of the bare essentials for understanding `VideoCore`
+- [ ] 'Getting Started' to front page
+- [ ] Examples to separate page under Docs
+- [ ] Mailbox functions link to reference and explanation two size fields
+
+
+## Unit Tests
+
+- [ ] Convert `AutoStart` to unit test
+- [ ] Test same output for the various versions of `Rot3D`
+
+
+### Unit testing for Debug
+
+- [ ] All combinations of options for `Debug::enable()`
+- [ ] Sequence: Open to file, open to other file
+- [ ] Sequence: to file, off, to same file, off, to different file
+- [ ] Sequence: stdout, to file, stdout
+
+
+## Class `Debug`
+
+- [ ] Consider renaming to `Log` and treat as such
+- [ ] Append (with header) instead of writing over existing logs
+
+
+## Other
+
+- [x] Add TODO to project
+- [ ] Add check in emulator for too many `gather()` calls
+- [ ] `Rot3D` make various versions selectable on command line
+- [ ] Add namespace `qpulib` to Lib-files
+- [ ] Add method to determine RPi version via mailbox
+- [ ] Prevent compile on non-RPi for `QPU=1`
+- [ ] enable `-Wall` on compilation and deal with all the fallout
+
+Additionally: should it be compilable at all?
+I.e. Following happens on compilation with `make QPU=1` on 64-bit Intel Linux:
+
+```
+SharedArray.h:121:14: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+      gpu_base = (void*) mem_lock(mb, handle);
+```
+
+-----
+
+## Stuff to Consider
+
+### Measure performance in various ways
+
+E.g. compare between:
+
+  - different iterations of a program
+  - number of QPU's used
+  - RPi versions
+  
+  
+### The QPULib compiler doesn't do much in the way of optimisation.
+
+So the question is how far QPULib programs are off hand-written QPU assembly, and what we can do to get closer.
+
+
+### Set up Guidelines for the Project
+
+This blog contains great tips for setting up open source projects: 
+
+- [The Bitter Guide to Open Source](https://medium.com/@ken_wheeler/a-bitter-guide-to-open-source-a8e3b6a3c1c4) by Ken Wheeler.
+
+One day, I would like to convert the points mentioned here to a checklist and implement these for `QPULib`.

--- a/Doc/TODO.md
+++ b/Doc/TODO.md
@@ -50,7 +50,7 @@ Feel free to add points here, or check them off if done.
 
 ## Investigate
 
-- [] Is the gather limit 8 or 4? This depends on threading being enabled, check code for this.
+- [ ] Is the gather limit 8 or 4? This depends on threading being enabled, check code for this.
 
 
 ## Other

--- a/Doc/TODO.md
+++ b/Doc/TODO.md
@@ -9,7 +9,7 @@ Feel free to add points here, or check them off if done.
 - [x] Raise the makefile one directory level and expand it
 - [x] Explanatory comment at top
 - [x] Static library for Lib-files
-- [ ] Add include-file dependencies
+- [x] Add include-file dependencies
 - [ ] Get rid of DEBUG option -> make debug output dynamic
 - [ ] Enable debug-build, for debugging
 - [ ] Add unit testing, notably `CATCH`
@@ -46,6 +46,11 @@ Feel free to add points here, or check them off if done.
 
 - [ ] Consider renaming to `Log` and treat as such
 - [ ] Append (with header) instead of writing over existing logs
+
+
+## Investigate
+
+- [] Is the gather limit 8 or 4? This depends on threading being enabled, check code for this.
 
 
 ## Other


### PR DESCRIPTION
Redo of #26 , this time branching from `development`.
Previous branched from another PR and contained too many commits.

Also added change to `.gitignore`.

-----
Previous text:

This is my complete TODO (and then some), made available for public use and scrutiny. I hope it proves useful to others.

I intend to update the `TODO.md` as I proceed. It is therefore a dynamic document.

The direct benefit for @mn416 is that he can now see what my intentions are wrt. the project in the foreseeable future. Hoping for feedback.