### PR TITLE
Fixed stale link to VideoCore Reference Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Times taken to simulate a 512x512 surface for 2000 steps:
 The following works were *very* helpful in the development of
 QPULib.
 
-  * The [VideoCore IV manual](http://www.broadcom.com/docs/support/videocore/VideoCoreIV-AG100-R.pdf) by Broadcom.
+  * The [VideoCore IV Reference Manual](https://docs.broadcom.com/docs-and-downloads/docs/support/videocore/VideoCoreIV-AG100-R.pdf) by Broadcom.
 
   * The [documentation, demos, and
     assembler](https://github.com/hermanhermitage/videocoreiv-qpu)


### PR DESCRIPTION
See title, mentioned in #33. Also adjusted link text.