### PR TITLE
Add command line parameter for selecting kernel to Rot3DLib

### DIFF
--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -5,7 +5,7 @@
 using namespace Rot3DLib;
 
 
-using Generator = decltype(rot3D_1);  // All kernel functions have same prototype
+using Generator = decltype(rot3D_1);  // All kernel functions except scalar have same prototype
 
 
 // Number of vertices and angle of rotation
@@ -35,6 +35,9 @@ timeval runScalar() {
   // Display results
   //for (int i = 0; i < N; i++)
   //  printf("%f %f\n", x[i], y[i]);
+
+	delete x;
+	delete y;
 
 	return tvDiff;
 }
@@ -83,8 +86,6 @@ timeval runKernel(int index) {
 	return tvDiff;
 }
 
-
-// #define USE_SCALAR_VERSION
 
 // ============================================================================
 // Main

--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -4,22 +4,18 @@
 
 using namespace Rot3DLib;
 
-// #define USE_SCALAR_VERSION
 
-// ============================================================================
-// Main
-// ============================================================================
+using Generator = decltype(rot3D_1);  // All kernel functions have same prototype
 
-int main()
-{
-  // Timestamps
-  timeval tvStart, tvEnd, tvDiff;
 
-  // Number of vertices and angle of rotation
-  const int N = 19200; // 192000
-  const float THETA = (float) 3.14159;
+// Number of vertices and angle of rotation
+const int N = 19200; // 192000
+const float THETA = (float) 3.14159;
 
-#ifdef USE_SCALAR_VERSION
+
+timeval runScalar() {
+	printf("Running scalar\n");
+
   // Allocate and initialise
   float* x = new float [N];
   float* y = new float [N];
@@ -27,9 +23,40 @@ int main()
     x[i] = (float) i;
     y[i] = (float) i;
   }
-#else
+
+  timeval tvStart, tvEnd, tvDiff;
+  gettimeofday(&tvStart, NULL);
+
+  rot3D(N, cosf(THETA), sinf(THETA), x, y);
+
+  gettimeofday(&tvEnd, NULL);
+  timersub(&tvEnd, &tvStart, &tvDiff);
+
+  // Display results
+  //for (int i = 0; i < N; i++)
+  //  printf("%f %f\n", x[i], y[i]);
+
+	return tvDiff;
+}
+
+
+timeval runKernel(int index) {
+	printf("Running kernel %d\n", index);
+
+	Generator *kGenerator = nullptr;
+
+	switch (index) {
+	  case 1: kGenerator = rot3D_1; break;
+	  case 2: kGenerator = rot3D_2; break;
+	  case 3: kGenerator = rot3D_3; break;
+		default:
+			printf("ERROR: No kernel with index %d\n", index);
+			exit(-1);
+  };
+	
+
   // Construct kernel
-  auto k = compile(rot3D_3);
+  auto k = compile(kGenerator);
 
   // Use 12 QPUs
   k.setNumQPUs(12);
@@ -40,21 +67,45 @@ int main()
     x[i] = (float) i;
     y[i] = (float) i;
   }
-#endif
 
+  timeval tvStart, tvEnd, tvDiff;
   gettimeofday(&tvStart, NULL);
-#ifdef USE_SCALAR_VERSION
-  rot3D(N, cosf(THETA), sinf(THETA), x, y);
-#else
+
   k(N, cosf(THETA), sinf(THETA), &x, &y);
-#endif
+
   gettimeofday(&tvEnd, NULL);
   timersub(&tvEnd, &tvStart, &tvDiff);
 
   // Display results
   //for (int i = 0; i < N; i++)
   //  printf("%f %f\n", x[i], y[i]);
- 
+
+	return tvDiff;
+}
+
+
+// #define USE_SCALAR_VERSION
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char *argv[])
+{
+  timeval tvDiff;
+
+	int index = 3;
+
+	if (argc > 1) {
+ 		index = atoi(argv[1]);
+  }
+
+	if (index == 0) {
+		tvDiff = runScalar();
+  } else {
+		tvDiff = runKernel(index);
+  }
+
   printf("%ld.%06lds\n", tvDiff.tv_sec, tvDiff.tv_usec);
 
   return 0;


### PR DESCRIPTION
This is the first evolution of `Rot3DLib`.

- A single command-line parameter is added to select the kernel to run.
- The scalar 'kernel' is selected with index 0.
- Internally, the code for the scalar and kernel versions have each been moved into its own function.