### PR TITLE
BUGFIX: Enable QPU when accessing Register Map

### DIFF
--- a/Lib/VideoCore/Mailbox.cpp
+++ b/Lib/VideoCore/Mailbox.cpp
@@ -42,6 +42,8 @@ namespace QPULib {
 
 void *mapmem(unsigned base, unsigned size)
 {
+   //printf("mapmem requested base: 0x%x, size: %d\n", base, size);
+
    int mem_fd;
    unsigned offset = base % PAGE_SIZE;
    base = base - offset;
@@ -63,7 +65,9 @@ void *mapmem(unsigned base, unsigned size)
 #endif  // DEBUG
 
    if (mem == MAP_FAILED) {
-      printf("mmap error %p\n", mem);
+      printf("mmap error value %p: ", mem);
+      fflush(stdout);
+      perror(nullptr);  // Prints error message on stdout
       exit (-1);
    }
    close(mem_fd);

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -24,8 +24,9 @@ public:
 
 	~RegisterMap();
 
-	static int numSlices();
-	static int numQPUPerSlice();
+	static bool enabled();
+	static int  numSlices();
+	static int  numQPUPerSlice();
 
 private:
 	RegisterMap();

--- a/Tests/testMain.cpp
+++ b/Tests/testMain.cpp
@@ -30,7 +30,7 @@
 //
 // This is a good place to put simple, global tests
 //
-const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_DEBUG "/bin/AutoTest";
+const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_QPU "/bin/AutoTest";
 
 
 TEST_CASE("Check random specifications for interpreter and emulator2", "[specs]") {

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -57,12 +57,24 @@ int main(int argc, char *argv[]) {
 	unsigned revision = get_version(mb);
 	printf("Hardware revision: %04x\n", revision);
 
+	bool wasEnabled = RegisterMap::enabled();
+	if (!wasEnabled) {
+		// VideoCore needs to be enabled, otherwise the registers can't be accessed.
+		//printf("VideoCore not running, enabling for this app\n");
+		qpu_enable(mb, 1);
+	}
+
 	if (geteuid() == 0) {  // Only do this as root (sudo)
 		printf("Number of slices: %d\n", RegisterMap::numSlices());
 		printf("Number of QPU's per slice: %d\n", RegisterMap::numQPUPerSlice());
 	} else {
 		printf("You can see more if you use sudo\n");
   }
+
+	if (!wasEnabled) {
+		//printf("Disabling the VideoCore again\n");
+		qpu_enable(mb, 0);
+	}
 #endif  // QPU_MODE
 
 	return 0;


### PR DESCRIPTION
Accessing the register map won't work if the VideoCore is not powered up. This PR adds code to `detectPlatform()` to ensure that VideoCore is enabled before reading the registers.
    
In addition:
    
- Adjusted some code for better debugging. Notably, a call to `perror` has been
  added in `MailBox.cpp`.
- Left in debug printf's where useful. These are commented out in general.
- Added `RegisterMap::enabled()`, which checks if the VideoCore registers are accessible.
    
The latter is actually a useful method to determine if the VideoCore is running.
