### PR TITLE
Bugfix: Better detection of Pi platform

### DIFF
--- a/Tests/testMain.cpp
+++ b/Tests/testMain.cpp
@@ -30,7 +30,7 @@
 //
 // This is a good place to put simple, global tests
 //
-const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_DEBUG "/bin/AutoTest";
+const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_QPU "/bin/AutoTest";
 
 
 TEST_CASE("Check random specifications for interpreter and emulator2", "[specs]") {

--- a/Tests/testMain.cpp
+++ b/Tests/testMain.cpp
@@ -35,18 +35,32 @@ using RegMap = QPULib::RegisterMap;
 	#define POSTFIX_QPU ""
 #endif
 
-const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_QPU "/bin/AutoTest";
+#define BIN_PATH "obj" POSTFIX_DEBUG POSTFIX_QPU "/bin"
+
 
 
 //
 // This is a good place to put simple, global tests
 //
-const char *AUTOTEST_PATH = "obj" POSTFIX_DEBUG POSTFIX_QPU "/bin/AutoTest";
+const char *AUTOTEST_PATH = BIN_PATH "/AutoTest";
 
 
-TEST_CASE("Check random specifications for interpreter and emulator2", "[specs]") {
+TEST_CASE("Check random specifications for interpreter and emulator2", "[specs][cmdline]") {
 	printf("Running AutoTest from '%s'\n", AUTOTEST_PATH);
 	REQUIRE(system(AUTOTEST_PATH) == 0);
+}
+
+
+TEST_CASE("Detect platform scripts should both return the same thing", "[cmdline]") {
+	printf("Running detectPlatform\n");
+	int ret1 = system(BIN_PATH "/detectPlatform");
+	bool success1 = (ret1 == 0);
+
+	int ret2 = system("Tools/detectPlatform.sh");
+	bool success2 = (ret2 == 0);
+
+	INFO("C++ script returned " << ret1 << ", shell script returned " << ret2);
+	REQUIRE(success1 == success2);
 }
 
 

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -69,7 +69,7 @@ bool detect_from_sys() {
  *
  * * The following are valid model numbers:
  *
- *  - BCM2807
+ *  - BCM2708
  *  - BCM2835    - This appears to be returned for all higher BCM versions
  *
  * * The following are also valid, but appear to be represented by 'BCM2835'
@@ -80,7 +80,7 @@ bool detect_from_sys() {
  *  - BCM2837B0
  */
 bool detect_from_proc() {
-	const char *BCM_VERSION_PREFIX = "BCM28";
+	const char *BCM_VERSION_PREFIX = "BCM2";
 	const char *filename = "/proc/cpuinfo";
 
 	std::ifstream t(filename);

--- a/Tools/detectPlatform.sh
+++ b/Tools/detectPlatform.sh
@@ -36,12 +36,11 @@ fi
 # Detect if this is a VideoCore. This should be sufficient for detecting Pi,
 # since it's the only thing to date(!) using this particular chip version.
 #
-# There are several model numbers possible, but they should all start
-# with 'BCM28'.
+# There are several model numbers possible, but they should all start with 'BCM2'.
 #
 
 # Prefix of allowed model numbers
-modelPrefix=BCM28
+modelPrefix=BCM2
 
 model=$(cat /proc/cpuinfo | grep Hardware | grep $modelPrefix)
 ret=$?

--- a/Tools/detectPlatform.sh
+++ b/Tools/detectPlatform.sh
@@ -9,6 +9,9 @@
 
 file=/sys/firmware/devicetree/base/model
 
+# This works for later version of Pi (distro's)
+if false; then
+
 if [ -f $file ]
 then
 	model=$(tr -d '\0' < $file)  # as `cat`, but avoid warning 'ignored null byte in input'
@@ -25,6 +28,19 @@ then
 		fi
 	fi
 fi
+
+fi
+
+# This should work for all Pi's
+# The hardware from Pi 2 onward is actually BCM2836, but the cat-call still returns BCM2835
+model=$(cat /proc/cpuinfo | grep Hardware | grep BCM2835 )
+ret=$?
+if [ $ret -eq 0 ]
+then
+	echo model checks out
+	exit 0
+fi
+
 
 echo This is not an RPi platform
 exit 1

--- a/Tools/detectPlatform.sh
+++ b/Tools/detectPlatform.sh
@@ -9,9 +9,9 @@
 
 file=/sys/firmware/devicetree/base/model
 
+#
 # This works for later version of Pi (distro's)
-if false; then
-
+#
 if [ -f $file ]
 then
 	model=$(tr -d '\0' < $file)  # as `cat`, but avoid warning 'ignored null byte in input'
@@ -29,18 +29,23 @@ then
 	fi
 fi
 
-fi
 
-# This should work for all Pi's
-# The hardware from Pi 2 onward is actually BCM2836, but the cat-call still returns BCM2835
+#
+# This should work for all Pi's.
+#
+# Detect if this is a VideoCore. This should be sufficient for detecting Pi,
+# since it's the only thing to date(!) using this particular chip version.
+#
+# The hardware from Pi 2 onward is actually BCM2836, but the call still returns BCM2835
+#
 model=$(cat /proc/cpuinfo | grep Hardware | grep BCM2835 )
 ret=$?
 if [ $ret -eq 0 ]
 then
-	echo model checks out
+	echo This is a Pi platform
 	exit 0
 fi
 
 
-echo This is not an RPi platform
+echo This is not a Pi platform
 exit 1


### PR DESCRIPTION
The attempted implementation for detecting if you're running on Pi does not work on early Pi versions (or distributions). This PR adds a fallback which should work on any version.

* Added platform check using `/proc/cpuinfo` to both C++ and shell versions of `detectPlatform`
* No attempt is made to determine the exact Pi model. The fallback just gives the message 'This is a Pi platform`.
* Added a unit test for the correct working of the platform detection scripts.