### PR TITLE
Add VPM size to detectPlatform output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 obj*
 .directory
 *.log
+*.pgm

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -72,6 +72,20 @@ int RegisterMap::numQPUPerSlice() {
 }
 
 
+/**
+ * @brief get the size of the VPM.
+ *
+ * @return Size of VPM in KB
+ */
+int RegisterMap::VPMSize() {
+	uint32_t reg = readRegister(V3D_IDENT1);
+	int value = (reg >> 28) & 0xf;
+
+	if (value == 0) return 16;  // According to reference doc p.97
+	return value;
+}
+
+
 RegisterMap *RegisterMap::instance() {
 	if (m_instance.get() == nullptr) {
 		m_instance.reset(new RegisterMap);

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -14,7 +14,8 @@ enum {
 	V3D_BASE = (0xc00000 >> 2),
 	V3D_IDENT0 = 0,
 	V3D_IDENT1,
-	V3D_IDENT2
+	V3D_IDENT2,
+	V3D_L2CACTL = (0x00020 >> 2)
 };
 
 std::unique_ptr<RegisterMap> RegisterMap::m_instance;
@@ -72,6 +73,11 @@ int RegisterMap::numQPUPerSlice() {
 }
 
 
+int RegisterMap::numTMUPerSlice() {
+	return (readRegister(V3D_IDENT1) >> 12) & 0xf;
+}
+
+
 /**
  * @brief get the size of the VPM.
  *
@@ -83,6 +89,11 @@ int RegisterMap::VPMSize() {
 
 	if (value == 0) return 16;  // According to reference doc p.97
 	return value;
+}
+
+
+int RegisterMap::L2CacheEnabled() {
+	return (readRegister(V3D_L2CACTL) & 0x1);
 }
 
 

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -10,9 +10,8 @@ namespace QPULib {
 /**
  * @brief interface for the VideoCore registers.
  *
- * This implementation is far from complete. It only reads
- * two fields from a single register. Regard it as a proof of
- * concept which can be expanded as needed.
+ * This implementation is far from complete.
+ * The reading of more registers can be added as needed.
  *
  * Implemented as singleton with lazy load, so that it's 
  * not initialized when it's not used.

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -25,8 +25,10 @@ public:
 	~RegisterMap();
 
 	static int numSlices();
+	static int numTMUPerSlice();
 	static int numQPUPerSlice();
 	static int VPMSize();
+	static int L2CacheEnabled();
 
 private:
 	RegisterMap();

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -26,6 +26,7 @@ public:
 
 	static int numSlices();
 	static int numQPUPerSlice();
+	static int VPMSize();
 
 private:
 	RegisterMap();

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -60,6 +60,7 @@ int main(int argc, char *argv[]) {
 	if (geteuid() == 0) {  // Only do this as root (sudo)
 		printf("Number of slices: %d\n", RegisterMap::numSlices());
 		printf("Number of QPU's per slice: %d\n", RegisterMap::numQPUPerSlice());
+		printf("Size of VPM: %dKB\n", RegisterMap::VPMSize());
 	} else {
 		printf("You can see more if you use sudo\n");
   }

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -120,9 +120,11 @@ int main(int argc, char *argv[]) {
 	printf("Hardware revision: %04x\n", revision);
 
 	if (geteuid() == 0) {  // Only do this as root (sudo)
-		printf("Number of slices: %d\n", RegisterMap::numSlices());
-		printf("Number of QPU's per slice: %d\n", RegisterMap::numQPUPerSlice());
-		printf("Size of VPM: %dKB\n", RegisterMap::VPMSize());
+		printf("Number of slices : %d\n",   RegisterMap::numSlices());
+		printf("QPU's per slice  : %d\n",   RegisterMap::numQPUPerSlice());
+		printf("TMU's per slice  : %d\n",   RegisterMap::numTMUPerSlice());
+		printf("Size of VPM      : %dKB\n", RegisterMap::VPMSize());
+		printf("L2 Cache enabled : %s\n",   (RegisterMap::L2CacheEnabled())? "yes": "no");
 	} else {
 		printf("You can see more if you use sudo\n");
   }


### PR DESCRIPTION
Now that DMA is enabled, it's interesting to know what the actual size is of the VPM.
This adds it to the output of `detectPlatform`.

Example output:

```
> sudo obj-qpu/bin/detectPlatform
Detected platform: Raspberry Pi 2 Model B Rev 1.1
Hardware revision: a01041
Number of slices: 3
Number of QPU's per slice: 4
Size of VPM: 12KB                    # <-- This is new

```

**NOTE:** This will probably not work on your machine until #52 and #53 have been merged.