### PR TITLE
New example: Mandelbrot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 obj*
 .directory
 *.log
+*.pgm

--- a/Examples/Mandelbrot.cpp
+++ b/Examples/Mandelbrot.cpp
@@ -7,8 +7,30 @@ using namespace QPULib;
 //#define USE_SCALAR_VERSION
 
 
+/**
+ * Two format limits need to be taken into account:
+ *
+ * - Max line length of 70 characters, 'count' handles this
+ * - Max gray value of 65536
+ */
 template<class Array>
 void output_pgm(Array &result, int width, int height, int numIterations) {
+	const int GrayLimit = 65536;
+	float factor = -1.0f;
+	int maxGray = numIterations;
+
+	if (maxGray > GrayLimit) {
+		// printf ("output_pgm adjust max gray\n");
+		factor = ((float) GrayLimit)/((float) maxGray);
+		maxGray = GrayLimit;
+	}
+
+	auto scale = [factor] (int value) -> int {
+		if (factor == -1.0f) return value;
+		return (int) (factor*((float) value));
+	};
+
+
   FILE *fd = fopen("mandelbrot.pgm", "w") ;
   if (fd == nullptr) {
     printf("can't open file for pgm output\n");
@@ -18,12 +40,12 @@ void output_pgm(Array &result, int width, int height, int numIterations) {
   // Write header
   fprintf(fd, "P2\n");
   fprintf(fd, "%d %d\n", width, height);
-  fprintf(fd, "%d\n", numIterations);
+  fprintf(fd, "%d\n", maxGray);
 
   int count = 0; // Limit output to 10 elements per line
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
-      fprintf(fd, "%d ", result[x + width*y]);
+      fprintf(fd, "%d ", scale(result[x + width*y]));
       count++;
       if (count >= 10) {
         fprintf(fd, "\n");
@@ -186,7 +208,6 @@ int main()
   const float topLeftIm       = 2.0f;
   const float bottomRightReal = 1.5f;
   const float bottomRightIm   = -2.0f;
-
 
 #ifdef USE_SCALAR_VERSION
   // Allocate and initialise

--- a/Examples/Mandelbrot.cpp
+++ b/Examples/Mandelbrot.cpp
@@ -7,11 +7,8 @@ using namespace QPULib;
 //#define USE_SCALAR_VERSION
 
 
-#ifdef USE_SCALAR_VERSION
-void output_pgm(int *result, int width, int height, int numIteratiosn) {
-#else
-void output_pgm(SharedArray<int> &result, int width, int height, int numIteratiosn) {
-#endif
+template<class Array>
+void output_pgm(Array &result, int width, int height, int numIteratiosn) {
   FILE *fd = fopen("mandelbrot.pgm", "w") ;
   if (fd == nullptr) {
     printf("can't open file for pgm output\n");
@@ -85,8 +82,8 @@ void mandelbrot(
 
 void mandelbrotCore(
   Float reC, Float imC,
-  Int resultIndex,
-  Int numiterations,
+  Int &resultIndex,
+  Int &numiterations,
   Ptr<Int> &result)
 {
   Float re = reC;
@@ -134,10 +131,11 @@ void mandelbrot_1(
 
     For (Int xStep = 0, xStep < numStepsWidth, xStep = xStep + 16)
       Float reC = reLine + offsetX*toFloat(index());
+			Int resultIndex = (xStep + index() + yStep*numStepsWidth);
 
       mandelbrotCore(
         reC, imC,
-        (xStep + index() + yStep*numStepsWidth),
+				resultIndex,
         numiterations,
         result);
 

--- a/Examples/Mandelbrot.cpp
+++ b/Examples/Mandelbrot.cpp
@@ -1,0 +1,132 @@
+/*
+#include <sys/ioctl.h>
+//nclude <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+*/
+#include <sys/time.h>
+#include <QPULib.h>
+
+
+using namespace QPULib;
+
+#define USE_SCALAR_VERSION
+
+
+void output_pgm(int *result, int width, int height, int numIteratiosn) {
+  FILE *fd = fopen("mandelbrot.pgm", "w") ;
+  if (fd == nullptr) {
+    printf("can't open file for pgm output\n");
+    return;
+  }
+
+  // Write header
+  fprintf(fd, "P2\n");
+  fprintf(fd, "%d %d\n", width, height);
+  fprintf(fd, "%d\n", numIteratiosn);
+
+  int count; // Limit output to 10 elements per line
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      fprintf(fd, "%d ", result[x + width*y]);
+      count++;
+      if (count >= 10) {
+        fprintf(fd, "\n");
+        count = 0;
+      }
+    }
+    fprintf(fd, "\n");
+  }
+
+
+  fclose(fd);
+}
+
+
+// ============================================================================
+// Scalar version
+// ============================================================================
+
+void mandelbrot(
+  float topLeftReal, float topLeftIm,
+  float bottomRightReal, float bottomRightIm,
+  int numStepsWidth, int numStepsHeight,
+  int numiterations,
+  int *result)
+{
+  float offsetX = (bottomRightReal - topLeftReal)/((float) numStepsWidth - 1);
+  float offsetY = (topLeftIm - bottomRightIm)/((float) numStepsHeight - 1);
+
+  for (int xStep = 0; xStep < numStepsWidth; xStep++) {
+    for (int yStep = 0; yStep < numStepsHeight; yStep++) {
+      float realC = topLeftReal   + ((float) xStep)*offsetX;
+      float imC   = bottomRightIm + ((float) yStep)*offsetY;
+
+      int count = 0;
+      float real = realC;
+      float im   = imC;
+      float radius = (real*real + im*im);
+      while (radius < 4 && count < numiterations) {
+        float tmpReal = real*real - im*im;
+        float tmpIm   = 2*real*im;
+        real = tmpReal + realC;
+        im   = tmpIm + imC;
+
+        radius = (real*real + im*im);
+        count++;
+      }
+
+      result[xStep + yStep*numStepsWidth] = count;
+    }
+  }
+}
+
+// TODO: Vector versions
+
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main()
+{
+  // Timestamps
+  timeval tvStart, tvEnd, tvDiff;
+
+  // Number of vertices and angle of rotation
+  const int numStepsWidth  = 1024;
+  const int numStepsHeight = 1024;
+  const int numiterations  = 1024;
+
+
+#ifdef USE_SCALAR_VERSION
+  // Allocate and initialise
+  int *result = new int [numStepsWidth*numStepsHeight];
+#else
+  // TODO: compile kernels, allocate memory
+#endif
+
+  gettimeofday(&tvStart, NULL);
+#ifdef USE_SCALAR_VERSION
+  mandelbrot(-2.5f, 2.0f, 1.5f, -2.0f, numStepsWidth, numStepsHeight, numiterations, result);
+  output_pgm(result, numStepsWidth, numStepsHeight, numiterations);
+#else
+  // TODO: run kernels
+#endif
+  gettimeofday(&tvEnd, NULL);
+  timersub(&tvEnd, &tvStart, &tvDiff);
+
+  printf("%ld.%06lds\n", tvDiff.tv_sec, tvDiff.tv_usec);
+
+  return 0;
+}

--- a/Examples/Mandelbrot.cpp
+++ b/Examples/Mandelbrot.cpp
@@ -111,7 +111,7 @@ void mandelbrotCore(
       imSquare = im*im;
       count++;
 
-      checkvar = (4.0f - (reSquare + imSquare))*toFloat(numiterations - count);
+      checkvar = condition; 
     End
   End
 
@@ -168,7 +168,8 @@ void mandelbrot_2(
       Int xIndex = index() + xStep;
       Int resultIndex = xIndex + yIndex*numStepsWidth;
 
-      If (resultIndex < (numStepsWidth*numStepsHeight))  // Only calculate if we're within bounds
+      For (Int dummy = 0, dummy < 1 && (resultIndex < (numStepsWidth*numStepsHeight)), dummy++)
+      //Where (resultIndex < (numStepsWidth*numStepsHeight))  // Only calculate if we're within bounds
         mandelbrotCore(
           (topLeftReal + offsetX*toFloat(xIndex)),
           (topLeftIm - toFloat(yIndex)*offsetY),
@@ -228,12 +229,12 @@ int main()
     &result);
 
 #endif
-  output_pgm(result, numStepsWidth, numStepsHeight, numiterations);
 
   gettimeofday(&tvEnd, NULL);
   timersub(&tvEnd, &tvStart, &tvDiff);
 
   printf("%ld.%06lds\n", tvDiff.tv_sec, tvDiff.tv_usec);
+  output_pgm(result, numStepsWidth, numStepsHeight, numiterations);
 
   return 0;
 }

--- a/Lib/Target/Emulator.h
+++ b/Lib/Target/Emulator.h
@@ -8,7 +8,7 @@
 
 #define NUM_LANES 16
 #define MAX_QPUS 12
-#define EMULATOR_HEAP_SIZE 3*65536
+#define EMULATOR_HEAP_SIZE 1024*65536
 #define VPM_SIZE 1024
 
 namespace QPULib {

--- a/Lib/VideoCore/Invoke.cpp
+++ b/Lib/VideoCore/Invoke.cpp
@@ -4,7 +4,7 @@
 #include "VideoCore/Mailbox.h"
 #include "VideoCore/VideoCore.h"
 
-#define QPU_TIMEOUT 10000
+#define QPU_TIMEOUT 100000
 
 namespace QPULib {
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ LIB = $(patsubst %,$(OBJ_DIR)/%,$(OBJ))
 # All programs in the Examples directory
 # NOTE: detectPlatform is in the 'Tools' directory, not in 'Examples'
 EXAMPLES =  \
+	Mandelbrot \
 	detectPlatform \
 	Tri       \
 	GCD       \


### PR DESCRIPTION
This adds the example program Mandelbrot, at least an initial version.

- Structure taken from `Rot3d`
- Scalar kernel only
- The scalar kernel is structured in such a way that I hope makes sense for QPU kernels
- Outputs a PGM bitmap with the result

Running times:
```
# Intel:
> obj-debug/bin/Mandelbrot 
0.869301s

# Pi 2:
> obj/bin/Mandelbrot 
13.470295s
```

The output PGM bitmap looks like this:


![mandelbrot](https://user-images.githubusercontent.com/769037/42870772-fed1fd30-8a78-11e8-9adb-258cf85a905d.png)
