### PR TITLE
Put timeout back to 10 seconds.

### DIFF
--- a/Lib/VideoCore/Invoke.cpp
+++ b/Lib/VideoCore/Invoke.cpp
@@ -4,7 +4,7 @@
 #include "VideoCore/Mailbox.h"
 #include "VideoCore/VideoCore.h"
 
-#define QPU_TIMEOUT 100000
+#define QPU_TIMEOUT 10000
 
 namespace QPULib {
 


### PR DESCRIPTION
One-liner fix to set the `QPU_TIMEOUT` back to its original value of 10s.

There's no reason to keep it at 100s. I only needed it for an interim test.