### PR TITLE
DRY mkFloatExp()

### DIFF
--- a/Lib/Source/Float.cpp
+++ b/Lib/Source/Float.cpp
@@ -13,9 +13,6 @@ FloatExpr::FloatExpr() { this->expr = NULL; }
 
 FloatExpr::FloatExpr(float x) { this->expr = mkFloatLit(x); }
 
-// Helper constructor
-
-inline FloatExpr mkFloatExpr(Expr* e) { FloatExpr x; x.expr = e; return x; }
 
 // ============================================================================
 // Type 'Float'

--- a/Lib/Source/Float.h
+++ b/Lib/Source/Float.h
@@ -47,6 +47,11 @@ struct Float {
   FloatExpr operator=(FloatExpr rhs);
 };
 
+
+// Helper constructor
+
+inline FloatExpr mkFloatExpr(Expr* e) { FloatExpr x; x.expr = e; return x; }
+
 // ============================================================================
 // Operations
 // ============================================================================

--- a/Lib/Source/Int.cpp
+++ b/Lib/Source/Int.cpp
@@ -17,7 +17,6 @@ IntExpr::IntExpr(int x) { this->expr = mkIntLit(x); }
 // Helper constructor
 
 inline IntExpr mkIntExpr(Expr* e) { IntExpr x; x.expr = e; return x; }
-inline FloatExpr mkFloatExpr(Expr* e) { FloatExpr x; x.expr = e; return x; }
 
 // ============================================================================
 // Type 'Int'


### PR DESCRIPTION
Small DRY fix. `mkFloatExp()` was defined in two places, this puts it in one single place.