### PR TITLE
Added Errata link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ Times taken to simulate a 512x512 surface for 2000 steps:
 The following works were *very* helpful in the development of
 QPULib.
 
-  * The [VideoCore IV Reference Manual](https://docs.broadcom.com/docs-and-downloads/docs/support/videocore/VideoCoreIV-AG100-R.pdf) by Broadcom.
+  * The [VideoCore IV Reference Manual](https://docs.broadcom.com/docs-and-downloads/docs/support/videocore/VideoCoreIV-AG100-R.pdf) by Broadcom. [Errata](https://www.elinux.org/VideoCore_IV_3D_Architecture_Reference_Guide_errata).
 
   * The [documentation, demos, and
     assembler](https://github.com/hermanhermitage/videocoreiv-qpu)


### PR DESCRIPTION
Small fix that adds a link to README.

This links to a wiki page with corrections to the `VideoCore IV Reference Guide`.
The errata have helped me already; I think it's important that they are easily accessible.