### PR TITLE
Add  handling of Performance Counter registers

### DIFF
--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -4,8 +4,7 @@
 #include "Rot3DKernels.h"
 
 using namespace Rot3DLib;
-
-
+using PC = PerformanceCounters;
 using Generator = decltype(rot3D_1);  // All kernel functions except scalar have same prototype
 
 
@@ -88,13 +87,31 @@ timeval runKernel(int index) {
 }
 
 
+/**
+ * @brief Enable the counters we are interested in
+ */
+void initPerfCounters() {
+	PC::Init list[] = {
+		{ 0, PC::QPU_IDLE },
+		{ 1, PC::QPU_INSTRUCTIONS },
+		{ 2, PC::QPU_IDLE },
+		{ PC::END_MARKER, PC::END_MARKER }
+	};
+
+	PC::enable(list);
+}
+
+
 // ============================================================================
 // Main
 // ============================================================================
 
 int main(int argc, char *argv[])
 {
-	printf("Perf Count mask: %0X\n", PerformanceCounters::enabled());
+	initPerfCounters();
+	printf("Perf Count mask: %0X\n", PC::enabled());
+	std::string output = PC::showEnabled();
+	printf("%s\n", output.c_str());
 
   timeval tvDiff;
 
@@ -109,6 +126,9 @@ int main(int argc, char *argv[])
   } else {
 		tvDiff = runKernel(index);
   }
+
+	output = PC::showEnabled();
+	printf("%s\n", output.c_str());
 
   printf("%ld.%06lds\n", tvDiff.tv_sec, tvDiff.tv_usec);
 

--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -93,19 +93,28 @@ timeval runKernel(int index) {
  */
 void initPerfCounters() {
 	PC::Init list[] = {
-		{ 0, PC::QPU_IDLE },
-		{ 1, PC::QPU_INSTRUCTIONS },
-		{ 2, PC::QPU_STALLED_TMU },
-		{ 3, PC::L2C_CACHE_HITS },
-		{ 4, PC::L2C_CACHE_MISSES },
-		{ 5, PC::QPU_INSTRUCTION_CACHE_HITS },
-		{ 6, PC::QPU_INSTRUCTION_CACHE_MISSES },
-		{ 7, PC::QPU_CACHE_HITS },
-		{ 8, PC::QPU_CACHE_MISSES },
+		{ 0, PC::QPU_INSTRUCTIONS },
+		{ 1, PC::QPU_STALLED_TMU },
+		{ 2, PC::L2C_CACHE_HITS },
+		{ 3, PC::L2C_CACHE_MISSES },
+		{ 4, PC::QPU_INSTRUCTION_CACHE_HITS },
+		{ 5, PC::QPU_INSTRUCTION_CACHE_MISSES },
+		{ 6, PC::QPU_CACHE_HITS },
+		{ 7, PC::QPU_CACHE_MISSES },
+		{ 8, PC::QPU_IDLE },
 		{ PC::END_MARKER, PC::END_MARKER }
 	};
 
 	PC::enable(list);
+	PC::clear(PC::enabled());
+
+	//printf("Perf Count mask: %0X\n", PC::enabled());
+
+	// The following will show zeroes for all counters, *except*
+	// for QPU_IDLE, because this was running from the clear statement.
+	// Perhaps there are more counters like that.
+	//std::string output = PC::showEnabled();
+	//printf("%s\n", output.c_str());
 }
 
 
@@ -115,11 +124,7 @@ void initPerfCounters() {
 
 int main(int argc, char *argv[])
 {
-	//PC::clear();
 	initPerfCounters();
-	printf("Perf Count mask: %0X\n", PC::enabled());
-	std::string output = PC::showEnabled();
-	printf("%s\n", output.c_str());
 
   timeval tvDiff;
 
@@ -132,13 +137,11 @@ int main(int argc, char *argv[])
 	if (index == 0) {
 		tvDiff = runScalar();
   } else {
-for (int i = 0; i <10; ++i) {
 		tvDiff = runKernel(index);
-}
   }
 
-	//sleep(2);
-	output = PC::showEnabled();
+	// Show values current counters
+	std::string output = PC::showEnabled();
 	printf("%s\n", output.c_str());
 
   printf("%ld.%06lds\n", tvDiff.tv_sec, tvDiff.tv_usec);

--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -100,6 +100,8 @@ void initPerfCounters() {
 		{ 4, PC::L2C_CACHE_MISSES },
 		{ 5, PC::QPU_INSTRUCTION_CACHE_HITS },
 		{ 6, PC::QPU_INSTRUCTION_CACHE_MISSES },
+		{ 7, PC::QPU_CACHE_HITS },
+		{ 8, PC::QPU_CACHE_MISSES },
 		{ PC::END_MARKER, PC::END_MARKER }
 	};
 

--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -1,4 +1,5 @@
 #include <sys/time.h>
+#include <unistd.h>  // sleep()
 #include <math.h>
 #include "VideoCore/PerformanceCounters.h"
 #include "Rot3DKernels.h"
@@ -94,7 +95,11 @@ void initPerfCounters() {
 	PC::Init list[] = {
 		{ 0, PC::QPU_IDLE },
 		{ 1, PC::QPU_INSTRUCTIONS },
-		{ 2, PC::QPU_IDLE },
+		{ 2, PC::QPU_STALLED_TMU },
+		{ 3, PC::L2C_CACHE_HITS },
+		{ 4, PC::L2C_CACHE_MISSES },
+		{ 5, PC::QPU_INSTRUCTION_CACHE_HITS },
+		{ 6, PC::QPU_INSTRUCTION_CACHE_MISSES },
 		{ PC::END_MARKER, PC::END_MARKER }
 	};
 
@@ -108,6 +113,7 @@ void initPerfCounters() {
 
 int main(int argc, char *argv[])
 {
+	//PC::clear();
 	initPerfCounters();
 	printf("Perf Count mask: %0X\n", PC::enabled());
 	std::string output = PC::showEnabled();
@@ -124,9 +130,12 @@ int main(int argc, char *argv[])
 	if (index == 0) {
 		tvDiff = runScalar();
   } else {
+for (int i = 0; i <10; ++i) {
 		tvDiff = runKernel(index);
+}
   }
 
+	//sleep(2);
 	output = PC::showEnabled();
 	printf("%s\n", output.c_str());
 

--- a/Examples/Rot3DLib/Rot3DLib.cpp
+++ b/Examples/Rot3DLib/Rot3DLib.cpp
@@ -1,5 +1,6 @@
 #include <sys/time.h>
 #include <math.h>
+#include "VideoCore/PerformanceCounters.h"
 #include "Rot3DKernels.h"
 
 using namespace Rot3DLib;
@@ -93,6 +94,8 @@ timeval runKernel(int index) {
 
 int main(int argc, char *argv[])
 {
+	printf("Perf Count mask: %0X\n", PerformanceCounters::enabled());
+
   timeval tvDiff;
 
 	int index = 3;

--- a/Lib/VideoCore/PerformanceCounters.cpp
+++ b/Lib/VideoCore/PerformanceCounters.cpp
@@ -105,8 +105,8 @@ void PerformanceCounters::enable(Init list[]) {
 		//printf("enable handling counter %d\n", list[i].counterIndex);
 		bitMask = bitMask | (1 << (list[i].slotIndex));
 	}
+  bitMask = bitMask & ALL_COUNTERS;   // Top 16 bits should be zero by specification
 	RM::writeRegister(RM::V3D_PCTRE, bitMask);
-
 }
 
 
@@ -130,7 +130,7 @@ std::string PerformanceCounters::showEnabled() {
 		printf("counterIndex: %d\n", counterIndex);
 		//fflush(stdout);
 
-		os << "  " <<  Description[counterIndex] << ":" << RM::readRegister(sourceIndex) << "\n";
+		os << "  " <<  Description[counterIndex] << ": " << RM::readRegister(sourceIndex) << "\n";
 	}
 
 	return os.str();

--- a/Lib/VideoCore/PerformanceCounters.cpp
+++ b/Lib/VideoCore/PerformanceCounters.cpp
@@ -1,0 +1,141 @@
+#ifdef QPU_MODE
+#include "PerformanceCounters.h"
+#include <sstream>
+
+
+namespace QPULib {
+
+using RM = RegisterMap;
+
+
+/**
+ * Short versions of performance counter descriptions.
+ *
+ * These are intended as labels on display.
+ * The counter id is the index into the array.
+ * Padded for display.
+ *
+ * See: "VideoCore® IV 3D Architecture Reference Guide, Table 82: Sources for Performance Counters", page 97.
+ */
+const char *PerformanceCounters::Description[PerformanceCounters::NUM_PERF_COUNTERS] = {
+	// FEP Valid primitives for all rendered tiles
+  "No rendered pixels                ",   // index 0
+	"Valid primitives                  ",
+	// FEP
+	"Early-Z/Near/Far clipped quads    ",
+	"Valid quads                       ",
+	// TLB Quads pixels
+	"Failing stencil test              ",
+	"Failing Z and stencil tests       ",    // index 5
+	"Any failing Z and stencil tests   ",
+	"All having zero coverage          ",
+	"Any having non-zero coverage      ",
+	"Valid written to color buffer     ",
+  // PTB Primitives
+	"Outside the viewport              ",    // index 10
+	"Need clipping                     ",
+	// PSE Primitives
+	"Discarded, reversed               ",
+	// QPU Total clock cycles for all QPUs
+	"Idle                              ",
+	"Doing vertex/coordinate shading   ",
+	"Doing fragment shading            ",    // index 15
+	"Executing valid instructions      ",
+	"Stalled waiting for TMUs          ",
+	"Stalled waiting for Scoreboard    ",
+	"Stalled waiting for Varyings      ",
+	// QPU Total, for all slices
+	"Instruction cache hits            ",    // index 20
+	"Instruction cache misses          ",
+	"cache hits                        ",
+	"cache misses                      ",
+	// TMU texture, total
+	"Quads processed                   ",
+	"cache misses                      ",    // index 25 (number of fetches from memory/L2cache)
+	// VPM Total clock cycles
+	"VDW stalled waiting for VPM access",
+	"VCD stalled waiting for VPM access",
+	// L2C Total
+	"Level 2 cache hits                ",
+	"Level 2 cache misses              "     // index 29
+};
+
+
+/**
+ * @brief Reset the currently mapped performance counters
+ *
+ * @param bitMask  setting a bit to '1' clears the counter in the register corresponding to
+ *                 that index. Default: clear all counter registers.
+ */
+void PerformanceCounters::clear(uint32_t bitMask) {
+  bitMask = bitMask & ALL_COUNTERS;   // Top 16 bits should be zero by specification
+	RM::writeRegister(RM::V3D_PCTRC, bitMask);
+}
+
+
+/**
+ * @brief Return the bitmask for the enabled performance counters
+ *
+ * @return bitmaskr;, if bit 0 it '1', the performance counter 0 is enabled, etc.
+ */
+uint32_t PerformanceCounters::enabled() {
+	return RM::readRegister(RM::V3D_PCTRE);
+}
+
+
+/**
+ * ---------------------------
+ * ## NOTE:
+ *
+ * The passed counter definitions overwrite anything that is already present.
+ */
+void PerformanceCounters::enable(Init list[]) {
+	// Set enabling bitmask first
+	uint32_t bitMask = enabled();
+
+	for (int i = 0; !list[i].isEnd(); ++i) {
+		//printf("enable handling counter %d\n", list[i].counterIndex);
+		bitMask = bitMask | (1 << (list[i].slotIndex));
+	}
+	RM::writeRegister(RM::V3D_PCTRE, bitMask);
+
+	// Set the passed registers
+	for (int i = 0; !list[i].isEnd(); ++i) {
+		RM::Index targetIndex = (RM::Index) (RM::V3D_PCTRS0 + 2*list[i].slotIndex);
+		//printf("targetIndex: %d\n", targetIndex);
+		printf("counterIndex: %d\n", list[i].counterIndex);
+		RM::writeRegister(targetIndex, list[i].counterIndex);
+	}
+}
+
+
+/**
+ * @brief Create a string representations of the enabled counters and their values.
+ *
+ */
+std::string PerformanceCounters::showEnabled() {
+	uint32_t bitMask = enabled();
+	// printf("bitMask: %X\n", bitMask);
+	std::ostringstream os;
+
+	os << "Enabled counters:\n";
+
+	for (int i = 0; i < SLOT_COUNT; ++i) {
+		bool enabled = (0 != (bitMask & (1 << i)));
+		if (!enabled) continue;
+
+		RM::Index sourceIndex = (RM::Index) (RM::V3D_PCTR0 + 2*i);
+		Index counterIndex = (Index) RM::readRegister(sourceIndex + 1);
+		printf("counterIndex: %d\n", counterIndex);
+		//fflush(stdout);
+
+		os << "  " <<  Description[counterIndex] << ":" << RM::readRegister(counterIndex) << "\n";
+	}
+
+	return os.str();
+}
+
+}  // namespace QPULib
+
+
+#endif  // QPU_MODE

--- a/Lib/VideoCore/PerformanceCounters.cpp
+++ b/Lib/VideoCore/PerformanceCounters.cpp
@@ -90,7 +90,15 @@ uint32_t PerformanceCounters::enabled() {
  * The passed counter definitions overwrite anything that is already present.
  */
 void PerformanceCounters::enable(Init list[]) {
-	// Set enabling bitmask first
+	// Set the passed registers
+	for (int i = 0; !list[i].isEnd(); ++i) {
+		RM::Index targetIndex = (RM::Index) (RM::V3D_PCTRS0 + 2*list[i].slotIndex);
+		//printf("targetIndex: %d\n", targetIndex);
+		printf("counterIndex: %d\n", list[i].counterIndex);
+		RM::writeRegister(targetIndex, list[i].counterIndex);
+	}
+
+	// Set enabling bitmask 
 	uint32_t bitMask = enabled();
 
 	for (int i = 0; !list[i].isEnd(); ++i) {
@@ -99,13 +107,6 @@ void PerformanceCounters::enable(Init list[]) {
 	}
 	RM::writeRegister(RM::V3D_PCTRE, bitMask);
 
-	// Set the passed registers
-	for (int i = 0; !list[i].isEnd(); ++i) {
-		RM::Index targetIndex = (RM::Index) (RM::V3D_PCTRS0 + 2*list[i].slotIndex);
-		//printf("targetIndex: %d\n", targetIndex);
-		printf("counterIndex: %d\n", list[i].counterIndex);
-		RM::writeRegister(targetIndex, list[i].counterIndex);
-	}
 }
 
 
@@ -129,7 +130,7 @@ std::string PerformanceCounters::showEnabled() {
 		printf("counterIndex: %d\n", counterIndex);
 		//fflush(stdout);
 
-		os << "  " <<  Description[counterIndex] << ":" << RM::readRegister(counterIndex) << "\n";
+		os << "  " <<  Description[counterIndex] << ":" << RM::readRegister(sourceIndex) << "\n";
 	}
 
 	return os.str();

--- a/Lib/VideoCore/PerformanceCounters.h
+++ b/Lib/VideoCore/PerformanceCounters.h
@@ -1,0 +1,84 @@
+#ifdef QPU_MODE
+
+#ifndef _QPULIB_PERFORMANCECOUNTERS_H
+#define _QPULIB_PERFORMANCECOUNTERS_H
+#include <string.h>
+#include "RegisterMap.h"
+
+
+namespace QPULib {
+
+class PerformanceCounters {
+ public:
+	enum {
+		SLOT_COUNT = 16,
+  	ALL_COUNTERS = (1 << SLOT_COUNT) - 1
+	};
+
+
+	/**
+	 * Descriptive names for the counter indexes.
+	 *
+	 * These are made up and not part of the reference doc.
+	 * Derived from the counter descriptions.
+	 */
+	enum Index {
+		FEP_NO_RENDERED_PIXELS,
+		FEP_VALID_PRIMITIVES,
+		FEP_CLIPPED_QUADS,
+		FEP_VALID_QUADS,
+		TLB_ALL_FAILING_STENCIL,
+		TLB_ALL_FAILING_Z_AND_STENCIL,
+		TLB_ANY_FAILING_Z_AND_STENCIL,
+		TLB_ALL_ZERO_COVERAGE,
+		TLB_ANY_NONZERO_COVERAGE,
+		TLB_VALID_WRITTEN,
+		PTB_OUTSIDE_VIEWPORT,
+		PTB_NEED_CLIPPING,
+		PSE_DISCARDED_REVERSED,
+		QPU_IDLE,
+		QPU_VERTEX_SHADING,
+		QPU_FRAGMENT_SHADING,
+		QPU_INSTRUCTIONS,
+		QPU_STALLED_TMU,
+		QPU_STALLED_SCOREBOARD,
+		QPU_STALLED_VARYINGS,
+		QPU_INSTRUCTION_CACHE_HITS,
+		QPU_INSTRUCTION_CACHE_MISSES,
+		QPU_CACHE_HITS,
+		QPU_CACHE_MISSES,
+		TMU_QUADS_PROCESSED,
+		TMU_CACHE_MISSES,
+		VPM_VDW_STALLED,
+		VPM_VCD_STALLED,
+		L2C_CACHE_HITS,
+		L2C_CACHE_MISSES,
+
+		NUM_PERF_COUNTERS,  // Should be 30
+		END_MARKER
+	};
+
+
+	// Convenience struct to facilitate enabling of timers
+	struct Init {
+		uint32_t slotIndex;
+		Index    counterIndex;
+
+		bool isEnd() const { return (slotIndex == END_MARKER); }
+	};
+
+
+  static void clear(uint32_t bitMask = ALL_COUNTERS);
+	static uint32_t enabled();
+	static void enable(Init list[]);
+	static std::string showEnabled();
+
+ private:
+	static const char *Description[NUM_PERF_COUNTERS];
+};
+
+}  // namespace QPULib
+
+#endif  // _QPULIB_PERFORMANCECOUNTERS_H
+
+#endif  // QPU_MODE

--- a/Lib/VideoCore/PerformanceCounters.h
+++ b/Lib/VideoCore/PerformanceCounters.h
@@ -17,7 +17,7 @@ class PerformanceCounters {
 
 
 	/**
-	 * Descriptive names for the counter indexes.
+	 * Descriptive enums for the counter indexes.
 	 *
 	 * These are made up and not part of the reference doc.
 	 * Derived from the counter descriptions.
@@ -71,6 +71,7 @@ class PerformanceCounters {
   static void clear(uint32_t bitMask = ALL_COUNTERS);
 	static uint32_t enabled();
 	static void enable(Init list[]);
+	static void disable(uint32_t bitMask = ALL_COUNTERS);
 	static std::string showEnabled();
 
  private:

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -10,12 +10,111 @@
 
 namespace QPULib {
 
+const int NUM_PERFORMANCE_COUNTERS = 30;
+
 enum {
 	V3D_BASE = (0xc00000 >> 2),
 	V3D_IDENT0 = 0,
 	V3D_IDENT1,
-	V3D_IDENT2
+	V3D_IDENT2,
+
+	//
+	// Performance counter registers.
+	//
+	// There are 30 performance counters, but only 16 registers available
+	// to access them. You therefore have to map beforehand the counters
+	// you are interested in to an available slot.
+	//
+	// PC: 'Performance Counter' below
+	//
+  V3D_PCTRC = (0x00670 >> 2),  // PC Clear     - write only
+	V3D_PCTRE,                   // PC Enables   - read/write
+	V3D_PCTR0,                   // PC Count 0   - read/write
+	V3D_PCTRS0,                  // PC Mapping 0 - read/write
+	V3D_PCTR1,                   // PC Count 1
+	V3D_PCTRS1,                  // PC Mapping 1
+	V3D_PCTR2,                   // etc.
+	V3D_PCTRS2,
+	V3D_PCTR3,
+	V3D_PCTRS3,
+	V3D_PCTR4,
+	V3D_PCTRS4,
+	V3D_PCTR5,
+	V3D_PCTRS5,
+	V3D_PCTR6,
+	V3D_PCTRS6,
+	V3D_PCTR7,
+	V3D_PCTRS7,
+	V3D_PCTR8,
+	V3D_PCTRS8,
+	V3D_PCTR9,
+	V3D_PCTRS9,
+	V3D_PCTR10,
+	V3D_PCTRS10,
+	V3D_PCTR11,
+	V3D_PCTRS11,
+	V3D_PCTR12,
+	V3D_PCTRS12,
+	V3D_PCTR13,
+	V3D_PCTRS13,
+	V3D_PCTR14,
+	V3D_PCTRS14,
+	V3D_PCTR15,
+	V3D_PCTRS15
 };
+
+
+/**
+ * Short versions of performance counter descriptions.
+ *
+ * These are intended as labels on display.
+ * The counter id is the index into the array.
+ *
+ * See: "VideoCore® IV 3D Architecture Reference Guide, Table 82: Sources for Performance Counters", page 97.
+ */
+static const char *PerformanceCounterDescription[NUM_PERFORMANCE_COUNTERS] = {
+	// FEP Valid primitives for all rendered tiles
+  "No rendered pixels",                    // index 0
+	"Valid primitives",
+	// FEP
+	"Early-Z/Near/Far clipped quads",
+	"Valid quads",
+	// TLB Quads pixels
+	"Failing stencil test",
+	"Failing Z and stencil tests",           // index 5
+	"Any failing Z and stencil tests",
+	"All having zero coverage",
+	"Any having non-zero coverage",
+	"Valid written to color buffer",
+  // PTB Primitives
+	"Outside the viewport",                  // index 10
+	"Need clipping",
+	// PSE Primitives
+	"Discarded, reversed",
+	// QPU Total clock cycles for all QPUs
+	"Idle",
+	"Doing vertex/coordinate shading",
+	"Doing fragment shading",                // index 15
+	"Executing valid instructions",
+	"Stalled waiting for TMUs",
+	"Stalled waiting for Scoreboard",
+	"Stalled waiting for Varyings",
+	// QPU Total, for all slices
+	"Instruction cache hits",                // index 20
+	"Instruction cache misses",
+	"cache hits",
+	"cache misses",
+	// TMU texture, total
+	"Quads processed",
+	"cache misses",                          // index 25 (number of fetches from memory/L2cache)
+	// VPM Total clock cycles
+	"VDW stalled waiting for VPM access",
+	"VCD stalled waiting for VPM access",
+	// L2C Total
+	"Level 2 cache hits",
+	"Level 2 cache misses"                  // index 29
+};
+
 
 std::unique_ptr<RegisterMap> RegisterMap::m_instance;
 
@@ -24,18 +123,19 @@ RegisterMap::RegisterMap() {
 	bcm_host_init();
 	unsigned addr = bcm_host_get_peripheral_address();
 	m_size = bcm_host_get_peripheral_size();
+	printf("peripheral address: %08X, size: %08X\n", addr, m_size);
 
 	check_page_align(addr);
 
 	// Following succeeds if it returns.
 	m_addr = (uint32_t *) mapmem(addr, m_size);
 	assert(m_addr != nullptr);
-	// printf("init address: %08X, size: %u\n", m_addr, m_size);
+	printf("init address: %08X, size: %u\n", m_addr, m_size);
 }
 
 
 RegisterMap::~RegisterMap() {
-	// printf("Closing down register map\n");
+	printf("Closing down register map\n");
 	unmapmem((void *) m_addr, m_size);
 	bcm_host_deinit();
 }
@@ -55,7 +155,7 @@ uint32_t RegisterMap::read(int offset) const {
  * This avoids having to use `instance()->` for every read access.
  */
 uint32_t RegisterMap::readRegister(int offset) {
-	return instance()->read(V3D_IDENT1);
+	return instance()->read(offset);
 }
 
 
@@ -63,17 +163,22 @@ int RegisterMap::numSlices() {
 	uint32_t reg = readRegister(V3D_IDENT1);
 	// printf("reg V3D_IDENT1: %08X\n", reg);
 
-	return (reg >> 4) & 0xf;
+	int ret = (reg >> 4) & 0xf;
+	//printf("numSlices ret: %d\n", ret);
+	return ret;
 }
 
 
 int RegisterMap::numQPUPerSlice() {
-	return (readRegister(V3D_IDENT1) >> 8) & 0xf;
+	int ret = (readRegister(V3D_IDENT1) >> 8) & 0xf;
+	//printf("numQPUPerSlice ret: %d\n", ret);
+	return ret;
 }
 
 
 RegisterMap *RegisterMap::instance() {
 	if (m_instance.get() == nullptr) {
+		printf("Creating RegisterMap singleton\n");
 		m_instance.reset(new RegisterMap);
 	}
 
@@ -93,6 +198,19 @@ void RegisterMap::check_page_align(unsigned addr) {
 		fprintf(stderr, "error: peripheral address is not aligned to page size\n");
 		exit(-1);
 	}
+
+	//printf("check_page_align addr %X is properly aligned\n", addr);
+}
+
+
+/**
+ * Reset the currently mapped performance counters
+ *
+ * @param bitMask  setting a bit to '1' clears the counter in the register corresponding to
+ *                 that index. Default: clear all counter registers.
+ */
+void RegisterMap::clearPerformanceCounters(int bitMask) {
+  bitMask = bitMask & ALL_COUNTERS;   // Top 16 bits should be zero by specification
 }
 
 }  // namespace QPULib

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -18,19 +18,19 @@ RegisterMap::RegisterMap() {
 	bcm_host_init();
 	unsigned addr = bcm_host_get_peripheral_address();
 	m_size = bcm_host_get_peripheral_size();
-	printf("peripheral address: %08X, size: %08X\n", addr, m_size);
+	//printf("peripheral address: %08X, size: %08X\n", addr, m_size);
 
 	check_page_align(addr);
 
 	// Following succeeds if it returns.
 	m_addr = (uint32_t *) mapmem(addr, m_size);
 	assert(m_addr != nullptr);
-	printf("init address: %08X, size: %u\n", m_addr, m_size);
+	//printf("init address: %08X, size: %u\n", m_addr, m_size);
 }
 
 
 RegisterMap::~RegisterMap() {
-	printf("Closing down register map\n");
+	//printf("Closing down register map\n");
 	unmapmem((void *) m_addr, m_size);
 	bcm_host_deinit();
 }
@@ -91,7 +91,7 @@ int RegisterMap::numQPUPerSlice() {
 
 RegisterMap *RegisterMap::instance() {
 	if (m_instance.get() == nullptr) {
-		printf("Creating RegisterMap singleton\n");
+		//printf("Creating RegisterMap singleton\n");
 		m_instance.reset(new RegisterMap);
 	}
 

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -10,111 +10,6 @@
 
 namespace QPULib {
 
-const int NUM_PERFORMANCE_COUNTERS = 30;
-
-enum {
-	V3D_BASE = (0xc00000 >> 2),
-	V3D_IDENT0 = 0,
-	V3D_IDENT1,
-	V3D_IDENT2,
-
-	//
-	// Performance counter registers.
-	//
-	// There are 30 performance counters, but only 16 registers available
-	// to access them. You therefore have to map beforehand the counters
-	// you are interested in to an available slot.
-	//
-	// PC: 'Performance Counter' below
-	//
-  V3D_PCTRC = (0x00670 >> 2),  // PC Clear     - write only
-	V3D_PCTRE,                   // PC Enables   - read/write
-	V3D_PCTR0,                   // PC Count 0   - read/write
-	V3D_PCTRS0,                  // PC Mapping 0 - read/write
-	V3D_PCTR1,                   // PC Count 1
-	V3D_PCTRS1,                  // PC Mapping 1
-	V3D_PCTR2,                   // etc.
-	V3D_PCTRS2,
-	V3D_PCTR3,
-	V3D_PCTRS3,
-	V3D_PCTR4,
-	V3D_PCTRS4,
-	V3D_PCTR5,
-	V3D_PCTRS5,
-	V3D_PCTR6,
-	V3D_PCTRS6,
-	V3D_PCTR7,
-	V3D_PCTRS7,
-	V3D_PCTR8,
-	V3D_PCTRS8,
-	V3D_PCTR9,
-	V3D_PCTRS9,
-	V3D_PCTR10,
-	V3D_PCTRS10,
-	V3D_PCTR11,
-	V3D_PCTRS11,
-	V3D_PCTR12,
-	V3D_PCTRS12,
-	V3D_PCTR13,
-	V3D_PCTRS13,
-	V3D_PCTR14,
-	V3D_PCTRS14,
-	V3D_PCTR15,
-	V3D_PCTRS15
-};
-
-
-/**
- * Short versions of performance counter descriptions.
- *
- * These are intended as labels on display.
- * The counter id is the index into the array.
- *
- * See: "VideoCore® IV 3D Architecture Reference Guide, Table 82: Sources for Performance Counters", page 97.
- */
-static const char *PerformanceCounterDescription[NUM_PERFORMANCE_COUNTERS] = {
-	// FEP Valid primitives for all rendered tiles
-  "No rendered pixels",                    // index 0
-	"Valid primitives",
-	// FEP
-	"Early-Z/Near/Far clipped quads",
-	"Valid quads",
-	// TLB Quads pixels
-	"Failing stencil test",
-	"Failing Z and stencil tests",           // index 5
-	"Any failing Z and stencil tests",
-	"All having zero coverage",
-	"Any having non-zero coverage",
-	"Valid written to color buffer",
-  // PTB Primitives
-	"Outside the viewport",                  // index 10
-	"Need clipping",
-	// PSE Primitives
-	"Discarded, reversed",
-	// QPU Total clock cycles for all QPUs
-	"Idle",
-	"Doing vertex/coordinate shading",
-	"Doing fragment shading",                // index 15
-	"Executing valid instructions",
-	"Stalled waiting for TMUs",
-	"Stalled waiting for Scoreboard",
-	"Stalled waiting for Varyings",
-	// QPU Total, for all slices
-	"Instruction cache hits",                // index 20
-	"Instruction cache misses",
-	"cache hits",
-	"cache misses",
-	// TMU texture, total
-	"Quads processed",
-	"cache misses",                          // index 25 (number of fetches from memory/L2cache)
-	// VPM Total clock cycles
-	"VDW stalled waiting for VPM access",
-	"VCD stalled waiting for VPM access",
-	// L2C Total
-	"Level 2 cache hits",
-	"Level 2 cache misses"                  // index 29
-};
-
 
 std::unique_ptr<RegisterMap> RegisterMap::m_instance;
 
@@ -142,10 +37,18 @@ RegisterMap::~RegisterMap() {
 
 
 /**
- * @brief Get the 32-bit value at the given offset in the map
+ * @brief Get the 32-bit value of the register at the given offset in the map
  */
 uint32_t RegisterMap::read(int offset) const {
 	return m_addr[V3D_BASE + offset];
+}
+
+
+/**
+ * @brief Set the 32-bit value of the register at the given offset in the map
+ */
+void RegisterMap::write(int offset, uint32_t value) {
+	m_addr[V3D_BASE + offset] = value;
 }
 
 
@@ -156,6 +59,16 @@ uint32_t RegisterMap::read(int offset) const {
  */
 uint32_t RegisterMap::readRegister(int offset) {
 	return instance()->read(offset);
+}
+
+
+/**
+ * @brief Convenience function for setting a register value.
+ *
+ * This avoids having to use `instance()->` for every write access.
+ */
+void RegisterMap::writeRegister(int offset, uint32_t value) {
+	instance()->write(offset, value);
 }
 
 
@@ -200,17 +113,6 @@ void RegisterMap::check_page_align(unsigned addr) {
 	}
 
 	//printf("check_page_align addr %X is properly aligned\n", addr);
-}
-
-
-/**
- * Reset the currently mapped performance counters
- *
- * @param bitMask  setting a bit to '1' clears the counter in the register corresponding to
- *                 that index. Default: clear all counter registers.
- */
-void RegisterMap::clearPerformanceCounters(int bitMask) {
-  bitMask = bitMask & ALL_COUNTERS;   // Top 16 bits should be zero by specification
 }
 
 }  // namespace QPULib

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -18,9 +18,57 @@ namespace QPULib {
  */
 class RegisterMap {
 public:
-	enum {
-  	ALL_COUNTERS = (1 << 16) - 1
+	enum Indexes {
+		V3D_BASE = (0xc00000 >> 2),
+		V3D_IDENT0 = 0,
+		V3D_IDENT1,
+		V3D_IDENT2,
+
+		//
+		// Performance counter registers.
+		//
+		// There are 30 performance counters, but only 16 registers available
+		// to access them. You therefore have to map beforehand the counters
+		// you are interested in to an available slot.
+		//
+		// PC: 'Performance Counter' below
+		//
+	  V3D_PCTRC = (0x00670 >> 2),  // PC Clear     - write only
+		V3D_PCTRE,                   // PC Enables   - read/write
+		V3D_PCTR0,                   // PC Count 0   - read/write
+		V3D_PCTRS0,                  // PC Mapping 0 - read/write
+		V3D_PCTR1,                   // PC Count 1
+		V3D_PCTRS1,                  // PC Mapping 1
+		V3D_PCTR2,                   // etc.
+		V3D_PCTRS2,
+		V3D_PCTR3,
+		V3D_PCTRS3,
+		V3D_PCTR4,
+		V3D_PCTRS4,
+		V3D_PCTR5,
+		V3D_PCTRS5,
+		V3D_PCTR6,
+		V3D_PCTRS6,
+		V3D_PCTR7,
+		V3D_PCTRS7,
+		V3D_PCTR8,
+		V3D_PCTRS8,
+		V3D_PCTR9,
+		V3D_PCTRS9,
+		V3D_PCTR10,
+		V3D_PCTRS10,
+		V3D_PCTR11,
+		V3D_PCTRS11,
+		V3D_PCTR12,
+		V3D_PCTRS12,
+		V3D_PCTR13,
+		V3D_PCTRS13,
+		V3D_PCTR14,
+		V3D_PCTRS14,
+		V3D_PCTR15,
+		V3D_PCTRS15
 	};
+
 
 	RegisterMap(RegisterMap const &) = delete;
 	void operator=(RegisterMap const &) = delete;
@@ -30,8 +78,8 @@ public:
 	static int numSlices();
 	static int numQPUPerSlice();
 
-  static void clearPerformanceCounters(int bitMask = ALL_COUNTERS);
 	static uint32_t readRegister(int offset);
+	static void writeRegister(int offset, uint32_t value);
 
 private:
 	RegisterMap();
@@ -42,6 +90,7 @@ private:
 	static std::unique_ptr<RegisterMap> m_instance;
 
 	uint32_t read(int offset) const;
+	void write(int offset, uint32_t value);
 
 	static RegisterMap *instance();
 	static void check_page_align(unsigned addr);

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -10,15 +10,18 @@ namespace QPULib {
 /**
  * @brief interface for the VideoCore registers.
  *
- * This implementation is far from complete. It only reads
- * two fields from a single register. Regard it as a proof of
- * concept which can be expanded as needed.
+ * This implementation is not complete. Registers and their
+ * handling will be added as needed.
  *
  * Implemented as singleton with lazy load, so that it's 
  * not initialized when it's not used.
  */
 class RegisterMap {
 public:
+	enum {
+  	ALL_COUNTERS = (1 << 16) - 1
+	};
+
 	RegisterMap(RegisterMap const &) = delete;
 	void operator=(RegisterMap const &) = delete;
 
@@ -26,6 +29,9 @@ public:
 
 	static int numSlices();
 	static int numQPUPerSlice();
+
+  static void clearPerformanceCounters(int bitMask = ALL_COUNTERS);
+	static uint32_t readRegister(int offset);
 
 private:
 	RegisterMap();
@@ -36,7 +42,6 @@ private:
 	static std::unique_ptr<RegisterMap> m_instance;
 
 	uint32_t read(int offset) const;
-	static uint32_t readRegister(int offset);
 
 	static RegisterMap *instance();
 	static void check_page_align(unsigned addr);

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -25,11 +25,17 @@ public:
 		V3D_IDENT2,
 
 		//
-		// Performance counter registers.
+		// Performance counter register slots.
 		//
 		// There are 30 performance counters, but only 16 registers available
-		// to access them. You therefore have to map beforehand the counters
-		// you are interested in to an available slot.
+		// to access them. You therefore have to map the counters you are
+		// interested in to an available slot.
+		//
+		// There is actually no use in specifying all names fully, except to
+		// have the list complete. Internally,  the counter registers are taken as offsets
+		// from the first (V3D_PCTR0 and V3D_PCTRS0), so for the list it's enough to specify
+		// only that one and set an enum for the end of the list.
+		// TODO: perhaps make this so
 		//
 		// PC: 'Performance Counter' below
 		//

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -35,7 +35,7 @@ public:
 		//
 	  V3D_PCTRC = (0x00670 >> 2),  // PC Clear     - write only
 		V3D_PCTRE,                   // PC Enables   - read/write
-		V3D_PCTR0,                   // PC Count 0   - read/write
+		V3D_PCTR0 = (0x00680 >> 2),  // PC Count 0   - read/write
 		V3D_PCTRS0,                  // PC Mapping 0 - read/write
 		V3D_PCTR1,                   // PC Count 1
 		V3D_PCTRS1,                  // PC Mapping 1

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -18,7 +18,7 @@ namespace QPULib {
  */
 class RegisterMap {
 public:
-	enum Indexes {
+	enum Index {
 		V3D_BASE = (0xc00000 >> 2),
 		V3D_IDENT0 = 0,
 		V3D_IDENT1,

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ OBJ =                         \
   Target/Encode.o             \
   VideoCore/Mailbox.o         \
   VideoCore/RegisterMap.o     \
+  VideoCore/PerformanceCounters.o \
   VideoCore/Invoke.o          \
   VideoCore/VideoCore.o
 
@@ -184,7 +185,7 @@ $(OBJ_DIR)/bin/Rot3DLib: $(OBJ_DIR)/Examples/Rot3DLib/Rot3DKernels.o
 
 $(OBJ_DIR)/bin/%: $(OBJ_DIR)/Examples/Rot3DLib/%.o $(QPU_LIB)
 	@echo Linking $@...
-	@$(CXX) $(CXX_FLAGS) $^ -o $@
+	@$(CXX) $(CXX_FLAGS) $(LIBS) $^ -o $@
 
 $(OBJ_DIR)/bin/%: $(OBJ_DIR)/Examples/%.o $(QPU_LIB)
 	@echo Linking $@...

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -60,6 +60,12 @@ int main(int argc, char *argv[]) {
 	if (geteuid() == 0) {  // Only do this as root (sudo)
 		printf("Number of slices: %d\n", RegisterMap::numSlices());
 		printf("Number of QPU's per slice: %d\n", RegisterMap::numQPUPerSlice());
+
+		// DEBUG: read first three registers
+		printf("Reg 0: %X\n", RegisterMap::readRegister(0));
+		printf("Reg 1: %X\n", RegisterMap::readRegister(1));
+		printf("Reg 2: %X\n", RegisterMap::readRegister(2));
+
 	} else {
 		printf("You can see more if you use sudo\n");
   }


### PR DESCRIPTION
This enables viewing and initialization of the performance registers in the `RegisterMap`.

These can be used for hardware profiling whern running kernels. Notably, they will be useful when optimizing the generated kernel code.

- A separate class `PerformanceCounters` has been added; this because the handling is pretty extensive and was 'polluting' `RegisterMap`.
- Example usage has been added to `Rot3DLib`.

**NOTE:** #52 needs to be merged for this to work on @mn416 's system.

----
It took me a while to get this to work because the full functionality was not documented. I needed the Errata (#65) to get it to work; a single bit needed to be set for that.

