### PR TITLE
Development - Added CMakeLists.txt files for cmake configuration, compilation and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ option(ENABLE_DEBUG "Output debug information from QPULib" OFF)
 option(ENABLE_QPU "Enable QPU (rpi only), otherwise emulate" OFF)
 
 if(${ENABLE_DEBUG})
-	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DDEBUG)
+	set(QPULIB_DEBUG 1)
 endif()
 
 if(${ENABLE_QPU})
-	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DQPU_MODE)
+	set(QPULIB_QPU_MODE 1)
 else()
-	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DEMULATION_MODE)
+	set(QPULIB_EMULATION_MODE 1)
 endif()
 
 STRING(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -21,7 +21,11 @@ STRING(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Lib)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Lib/qpulib_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/qpulib_config.h)
+include_directories(
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib
+	${CMAKE_CURRENT_BINARY_DIR}
+)
 
 set(
 	SOURCES
@@ -67,9 +71,14 @@ install(TARGETS
 )
 
 install(DIRECTORY
-	${CMAKE_CURRENT_SOURCE_DIR}/Lib
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/
 	DESTINATION include/QPULib
 	FILES_MATCHING PATTERN "*.h"
+)
+
+install(FILES
+	${CMAKE_CURRENT_BINARY_DIR}/qpulib_config.h
+	DESTINATION include
 )
 
 if(${BUILD_EXAMPLES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.1)
+project(QPULib CXX)
+set(CMAKE_CXX_STANDARD 14)
+
+option(BUILD_EXAMPLES "Build all examples in the example directory" OFF)
+option(ENABLE_DEBUG "Output debug information from QPULib" OFF)
+option(ENABLE_QPU "Enable QPU (rpi only), otherwise emulate" OFF)
+
+if(${ENABLE_DEBUG})
+	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DDEBUG)
+endif()
+
+if(${ENABLE_QPU})
+	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DQPU_MODE)
+else()
+	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DEMULATION_MODE)
+endif()
+
+STRING(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Lib)
+
+set(
+	SOURCES
+
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Kernel.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Syntax.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Int.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Float.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Stmt.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Pretty.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Translate.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Interpreter.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Source/Gen.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Syntax.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/SmallLiteral.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Pretty.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/RemoveLabels.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/CFG.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Liveness.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/RegAlloc.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/ReachingDefs.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Subst.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/LiveRangeSplit.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Satisfy.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/LoadStore.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Emulator.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/Target/Encode.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/VideoCore/Mailbox.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/VideoCore/Invoke.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib/VideoCore/VideoCore.cpp
+)
+
+add_library(qpu.a STATIC ${SOURCES})
+add_library(qpu.so SHARED ${SOURCES})
+
+set_target_properties(qpu.a PROPERTIES OUTPUT_NAME qpu)
+set_target_properties(qpu.so PROPERTIES OUTPUT_NAME qpu)
+
+install(TARGETS
+	qpu.a qpu.so
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY
+	${CMAKE_CURRENT_SOURCE_DIR}/Lib
+	DESTINATION include/QPULib
+	FILES_MATCHING PATTERN "*.h"
+)
+
+if(${BUILD_EXAMPLES})
+	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Examples)
+endif()

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.1)
+project(QPULib_Examples CXX)
+set(CMAKE_CXX_STANDARD 14)
+
+macro(add_executable _name)
+	_add_executable(${ARGV})
+	if(TARGET ${_name})
+		# link libqpu statically because we don't know if it has been installed yet
+		target_link_libraries(${_name} libqpu.a)
+
+		# ensure that the qpu library is built first, no matter if static or not
+		add_dependencies(${_name} qpu.so)
+		add_dependencies(${_name} qpu.a)
+	endif()
+endmacro()
+
+STRING(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Lib)
+link_directories(${CMAKE_CURRENT_BINARY_DIR}/../lib)
+
+add_executable(AutoTest ${CMAKE_CURRENT_SOURCE_DIR}/AutoTest.cpp)
+add_executable(DMA ${CMAKE_CURRENT_SOURCE_DIR}/DMA.cpp)
+add_executable(GCD ${CMAKE_CURRENT_SOURCE_DIR}/GCD.cpp)
+add_executable(HeatMap ${CMAKE_CURRENT_SOURCE_DIR}/HeatMap.cpp)
+add_executable(HeatMapScalar ${CMAKE_CURRENT_SOURCE_DIR}/HeatMapScalar.cpp)
+add_executable(Hello ${CMAKE_CURRENT_SOURCE_DIR}/Hello.cpp)
+add_executable(ID ${CMAKE_CURRENT_SOURCE_DIR}/ID.cpp)
+add_executable(Mandelbrot ${CMAKE_CURRENT_SOURCE_DIR}/Mandelbrot.cpp)
+add_executable(MultiTri ${CMAKE_CURRENT_SOURCE_DIR}/MultiTri.cpp)
+add_executable(OET ${CMAKE_CURRENT_SOURCE_DIR}/OET.cpp)
+add_executable(Print ${CMAKE_CURRENT_SOURCE_DIR}/Print.cpp)
+add_executable(ReqRecv ${CMAKE_CURRENT_SOURCE_DIR}/ReqRecv.cpp)
+add_executable(Rot3D ${CMAKE_CURRENT_SOURCE_DIR}/Rot3D.cpp)
+add_executable(Sort ${CMAKE_CURRENT_SOURCE_DIR}/Sort.cpp)
+add_executable(Tri ${CMAKE_CURRENT_SOURCE_DIR}/Tri.cpp)
+add_executable(TriFloat ${CMAKE_CURRENT_SOURCE_DIR}/TriFloat.cpp)

--- a/Lib/QPULib.h
+++ b/Lib/QPULib.h
@@ -1,6 +1,7 @@
 #ifndef _QPULIB_H_
 #define _QPULIB_H_
 
+#include "qpulib_config.h"
 #include "Source/Int.h"
 #include "Source/Float.h"
 #include "Source/Ptr.h"

--- a/Lib/Source/Cond.h
+++ b/Lib/Source/Cond.h
@@ -1,8 +1,8 @@
 #ifndef _QPULIB_SOURCE_COND_H_
 #define _QPULIB_SOURCE_COND_H_
 
-#include "Source/Syntax.h"
-#include "Source/Int.h"
+#include "../Source/Syntax.h"
+#include "../Source/Int.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Float.h
+++ b/Lib/Source/Float.h
@@ -4,7 +4,7 @@
 #define _QPULIB_SOURCE_FLOAT_H_
 
 #include <assert.h>
-#include "Source/Syntax.h"
+#include "../Source/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Gen.h
+++ b/Lib/Source/Gen.h
@@ -3,8 +3,8 @@
 #ifndef _QPULIB_GEN_H_
 #define _QPULIB_GEN_H_
 
-#include "Common/Seq.h"
-#include "Source/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Source/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Int.h
+++ b/Lib/Source/Int.h
@@ -4,8 +4,8 @@
 #define _QPULIB_SOURCE_INT_H_
 
 #include <assert.h>
-#include "Source/Syntax.h"
-#include "Source/Float.h"
+#include "../Source/Syntax.h"
+#include "../Source/Float.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Interpreter.h
+++ b/Lib/Source/Interpreter.h
@@ -2,15 +2,15 @@
 #define _QPULIB_INTERPRETER_H_
 
 #include <stdint.h>
-#include "Common/Seq.h"
-#include "Source/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Source/Syntax.h"
 
 // The interpreter works in a similar way to the emulator.  The
 // difference is that the former operates on source code and the
 // latter on target code.  We reuse a number of concepts of the
 // emulator in the interpreter.
 
-#include "Target/Emulator.h"
+#include "../Target/Emulator.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Pretty.h
+++ b/Lib/Source/Pretty.h
@@ -1,7 +1,7 @@
 #ifndef _QPULIB_SOURCE_PRETTY_H_
 #define _QPULIB_SOURCE_PRETTY_H_
 
-#include "Source/Syntax.h"
+#include "../Source/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Ptr.h
+++ b/Lib/Source/Ptr.h
@@ -5,7 +5,7 @@
 #define _QPULIB_SOURCE_PTR_H_
 
 #include <assert.h>
-#include "Source/Syntax.h"
+#include "../Source/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Stmt.h
+++ b/Lib/Source/Stmt.h
@@ -1,10 +1,10 @@
 #ifndef _QPULIB_SOURCE_STMT_H_
 #define _QPULIB_SOURCE_STMT_H_
 
-#include "Source/Cond.h"
-#include "Source/Syntax.h"
-#include "Source/Ptr.h"
-#include "Source/StmtExtra.h"
+#include "../Source/Cond.h"
+#include "../Source/Syntax.h"
+#include "../Source/Ptr.h"
+#include "../Source/StmtExtra.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Syntax.h
+++ b/Lib/Source/Syntax.h
@@ -3,8 +3,8 @@
 #ifndef _QPULIB_SOURCE_SYNTAX_H_
 #define _QPULIB_SOURCE_SYNTAX_H_
 
-#include "Common/Heap.h"
-#include "Common/Stack.h"
+#include "../Common/Heap.h"
+#include "../Common/Stack.h"
 
 namespace QPULib {
 

--- a/Lib/Source/Translate.h
+++ b/Lib/Source/Translate.h
@@ -1,9 +1,9 @@
 #ifndef _QPULIB_TRANSLATE_H_
 #define _QPULIB_TRANSLATE_H_
 
-#include "Common/Seq.h"
-#include "Source/Syntax.h"
-#include "Target/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Source/Syntax.h"
+#include "../Target/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Target/CFG.h
+++ b/Lib/Target/CFG.h
@@ -3,8 +3,8 @@
 #ifndef _QPULIB_CFG_H_
 #define _QPULIB_CFG_H_
 
-#include "Common/Seq.h"
-#include "Target/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Target/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Target/Emulator.h
+++ b/Lib/Target/Emulator.h
@@ -2,9 +2,9 @@
 #define _QPULIB_EMULATOR_H_
 
 #include <stdint.h>
-#include "Common/Seq.h"
-#include "Common/Queue.h"
-#include "Target/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Common/Queue.h"
+#include "../Target/Syntax.h"
 
 #define NUM_LANES 16
 #define MAX_QPUS 12

--- a/Lib/Target/Encode.h
+++ b/Lib/Target/Encode.h
@@ -2,8 +2,8 @@
 #define _QPULIB_ENCODE_H_
 
 #include <stdint.h>
-#include "Target/Syntax.h"
-#include "Common/Seq.h"
+#include "../Target/Syntax.h"
+#include "../Common/Seq.h"
 
 namespace QPULib {
 

--- a/Lib/Target/LiveRangeSplit.h
+++ b/Lib/Target/LiveRangeSplit.h
@@ -1,9 +1,9 @@
 #ifndef _QPULIB_LIVERANGESPLIT_H_
 #define _QPULIB_LIVERANGESPLIT_H_
 
-#include "Common/Seq.h"
-#include "Target/CFG.h"
-#include "Target/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Target/CFG.h"
+#include "../Target/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Target/Liveness.h
+++ b/Lib/Target/Liveness.h
@@ -3,9 +3,9 @@
 #ifndef _QPULIB_LIVENESS_H_
 #define _QPULIB_LIVENESS_H_
 
-#include "Common/Seq.h"
-#include "Target/Syntax.h"
-#include "Target/CFG.h"
+#include "../Common/Seq.h"
+#include "../Target/Syntax.h"
+#include "../Target/CFG.h"
 
 namespace QPULib {
 

--- a/Lib/Target/LoadStore.h
+++ b/Lib/Target/LoadStore.h
@@ -1,9 +1,9 @@
 #ifndef _QPULIB_LOADSTORE_H_
 #define _QPULIB_LOADSTORE_H_
 
-#include "Common/Seq.h"
-#include "Target/Syntax.h"
-#include "Source/Syntax.h"
+#include "../Common/Seq.h"
+#include "../Target/Syntax.h"
+#include "../Source/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Target/Pretty.h
+++ b/Lib/Target/Pretty.h
@@ -2,7 +2,7 @@
 #define _QPULIB_TARGET_PRETTY_H_
 
 #include <stdio.h>
-#include "Target/Syntax.h"
+#include "../Target/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/Target/ReachingDefs.h
+++ b/Lib/Target/ReachingDefs.h
@@ -3,9 +3,9 @@
 #ifndef _QPULIB_REACHINGDEFS_H_
 #define _QPULIB_REACHINGDEFS_H_
 
-#include "Common/Seq.h"
-#include "Target/Syntax.h"
-#include "Target/CFG.h"
+#include "../Common/Seq.h"
+#include "../Target/Syntax.h"
+#include "../Target/CFG.h"
 
 namespace QPULib {
 

--- a/Lib/Target/RegAlloc.h
+++ b/Lib/Target/RegAlloc.h
@@ -1,10 +1,10 @@
 #ifndef _QPULIB_REGALLOC_H_
 #define _QPULIB_REGALLOC_H_
 
-#include "Target/CFG.h"
-#include "Target/Liveness.h"
-#include "Target/Syntax.h"
-#include "Common/Seq.h"
+#include "../Target/CFG.h"
+#include "../Target/Liveness.h"
+#include "../Target/Syntax.h"
+#include "../Common/Seq.h"
 
 namespace QPULib {
 

--- a/Lib/Target/RemoveLabels.h
+++ b/Lib/Target/RemoveLabels.h
@@ -1,10 +1,10 @@
 #ifndef _QPULIB_REMOVELABELS_H_
 #define _QPULIB_REMOVELABELS_H_
 
-#include "Target/Syntax.h"
-#include "Target/CFG.h"
-#include "Target/Liveness.h"
-#include "Common/Seq.h"
+#include "../Target/Syntax.h"
+#include "../Target/CFG.h"
+#include "../Target/Liveness.h"
+#include "../Common/Seq.h"
 
 namespace QPULib {
 

--- a/Lib/Target/Satisfy.h
+++ b/Lib/Target/Satisfy.h
@@ -1,8 +1,8 @@
 #ifndef _QPULIB_SATISFY_H_
 #define _QPULIB_SATISFY_H_
 
-#include "Target/Syntax.h"
-#include "Target/CFG.h"
+#include "../Target/Syntax.h"
+#include "../Target/CFG.h"
 
 namespace QPULib {
 

--- a/Lib/Target/SmallLiteral.h
+++ b/Lib/Target/SmallLiteral.h
@@ -1,8 +1,8 @@
 #ifndef _QPULIB_SMALL_LITERAL_H_
 #define _QPULIB_SMALL_LITERAL_H_
 
-#include "Source/Syntax.h"
-#include "Target/Emulator.h"
+#include "../Source/Syntax.h"
+#include "../Target/Emulator.h"
 
 namespace QPULib {
 

--- a/Lib/Target/Subst.h
+++ b/Lib/Target/Subst.h
@@ -1,7 +1,7 @@
 #ifndef _QPULIB_SUBST_H_
 #define _QPULIB_SUBST_H_
 
-#include "Target/Syntax.h"
+#include "../Target/Syntax.h"
 
 namespace QPULib {
 

--- a/Lib/VideoCore/Invoke.cpp
+++ b/Lib/VideoCore/Invoke.cpp
@@ -1,6 +1,6 @@
-#ifdef QPU_MODE
-
 #include "VideoCore/Invoke.h"
+
+#ifdef QPULIB_QPU_MODE
 #include "VideoCore/Mailbox.h"
 #include "VideoCore/VideoCore.h"
 
@@ -53,4 +53,4 @@ void invoke(
 
 }  // namespace QPULib
 
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE

--- a/Lib/VideoCore/Invoke.h
+++ b/Lib/VideoCore/Invoke.h
@@ -1,10 +1,11 @@
-#ifdef QPU_MODE
-
 #ifndef _QPULIB_INVOKE_H_
 #define _QPULIB_INVOKE_H_
 
-#include "Common/Seq.h"
-#include "VideoCore/SharedArray.h"
+#include "qpulib_config.h"
+
+#ifdef QPULIB_QPU_MODE
+#include "../Common/Seq.h"
+#include "../VideoCore/SharedArray.h"
 #include <stdint.h>
 
 namespace QPULib {
@@ -17,5 +18,5 @@ void invoke(
 
 }  // namespace QPULib
 
+#endif  // QPULIB_QPU_MODE
 #endif  // _QPULIB_INVOKE_H_
-#endif  // QPU_MODE

--- a/Lib/VideoCore/RegisterMap.cpp
+++ b/Lib/VideoCore/RegisterMap.cpp
@@ -1,6 +1,6 @@
-#ifdef QPU_MODE
-
 #include "RegisterMap.h"
+#ifdef QPULIB_QPU_MODE
+
 #include <cassert>
 #include <cstring>
 #include <stdio.h>
@@ -97,4 +97,4 @@ void RegisterMap::check_page_align(unsigned addr) {
 
 }  // namespace QPULib
 
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE

--- a/Lib/VideoCore/RegisterMap.h
+++ b/Lib/VideoCore/RegisterMap.h
@@ -1,7 +1,9 @@
-#ifdef QPU_MODE
-
 #ifndef _QPULIB_REGISTERMAP_H
 #define _QPULIB_REGISTERMAP_H
+
+#include "qpulib_config.h"
+#ifdef QPULIB_QPU_MODE
+
 #include <memory>
 #include <stdint.h>
 
@@ -44,6 +46,5 @@ private:
 
 }  // namespace QPULib
 
+#endif  // QPULIB_QPU_MODE
 #endif  // _QPULIB_REGISTERMAP_H
-
-#endif  // QPU_MODE

--- a/Lib/VideoCore/SharedArray.h
+++ b/Lib/VideoCore/SharedArray.h
@@ -1,33 +1,35 @@
 #ifndef _QPULIB_SHAREDARRAY_H_
 #define _QPULIB_SHAREDARRAY_H_
 
-#if !defined(QPU_MODE) && !defined(EMULATION_MODE)
+#include "qpulib_config.h"
+
+#if !defined(QPULIB_QPU_MODE) && !defined(QPULIB_EMULATION_MODE)
 //
 // Detect mode, set default if none defined.
 // This is the best place to test it in the code, since it's
 // the first of the header files to be compiled.
 //
-#pragma message "WARNING: QPU_MODE and EMULATION_MODE not defined, defaulting to EMULATION_MODE"
-#define EMULATION_MODE
+#pragma message "WARNING: QPULIB_QPU_MODE and QPULIB_EMULATION_MODE not defined, defaulting to QPULIB_EMULATION_MODE"
+#define QPULIB_EMULATION_MODE
 #endif
 
 #include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
-#include "VideoCore/Mailbox.h"
-#include "VideoCore/VideoCore.h"
+#include "../VideoCore/Mailbox.h"
+#include "../VideoCore/VideoCore.h"
 
 namespace QPULib {
 
-#ifdef EMULATION_MODE
+#ifdef QPULIB_EMULATION_MODE
 
 // ============================================================================
 // Emulation mode
 // ============================================================================
 
-// When in EMULATION_MODE allocate memory from a pre-allocated pool.
+// When in QPULIB_EMULATION_MODE allocate memory from a pre-allocated pool.
 
-#include "Target/Emulator.h"
+#include "../Target/Emulator.h"
 
 // Implementation
 template <typename T> class SharedArray {

--- a/Lib/VideoCore/VideoCore.cpp
+++ b/Lib/VideoCore/VideoCore.cpp
@@ -1,10 +1,11 @@
-#ifdef QPU_MODE
+#include "VideoCore.h"
+
+#ifdef QPULIB_QPU_MODE
+#include "Mailbox.h"
 
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "VideoCore/VideoCore.h"
-#include "VideoCore/Mailbox.h"
 
 namespace QPULib {
 
@@ -46,4 +47,4 @@ void disableQPUs()
 
 }  // namespace QPULib
 
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE

--- a/Lib/VideoCore/VideoCore.h
+++ b/Lib/VideoCore/VideoCore.h
@@ -1,7 +1,8 @@
-#ifdef QPU_MODE
-
 #ifndef _QPULIB_VIDEOCORE_H_
 #define _QPULIB_VIDEOCORE_H_
+
+#include "qpulib_config.h"
+#ifdef QPULIB_QPU_MODE
 
 namespace QPULib {
 
@@ -16,5 +17,5 @@ void disableQPUs();
 
 }  // namespace QPULib
 
+#endif  // QPULIB_QPU_MODE
 #endif  // _QPULIB_VIDEOCORE_H_
-#endif  // QPU_MODE

--- a/Lib/qpulib_config.h.in
+++ b/Lib/qpulib_config.h.in
@@ -1,0 +1,8 @@
+#ifndef _QPULIB_CONFIG_H
+#define _QPULIB_CONFIG_H
+
+#cmakedefine QPULIB_DEBUG
+#cmakedefine QPULIB_QPU_MODE
+#cmakedefine QPULIB_EMULATION_MODE
+
+#endif

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ introduces and documents QPULib.  For build instructions, see the
     * [Scalar version](#scalar-version-2)
     * [Vector version](#vector-version)
     * [Performance](#performance-1)
+* [Compiling](#compiling)
 * [References](#user-content-references)
 
 ## Background
@@ -668,6 +669,20 @@ Times taken to simulate a 512x512 surface for 2000 steps:
   Vector  | 2              | 24.91        |
   Vector  | 4              | 20.36        |
 
+### Compiling
+
+Compiling this project requires CMake (>=3.1).
+
+  * git clone ${clone url}
+  * cd QPULib
+  * cmake
+	* -DENABLE_QPU=ON will enable the QPU (rpi only)
+	* -DBUILD_EXAMPLES=ON will build all examples in the Examples subdirectory
+	* -DENABLE_DEBUG=ON will cause QPULib to compile with debug output to stdout
+  * make
+  * (optional) sudo make install # installs libraries and headers to CMAKE_INSTALL_PREFIX/{lib,include}
+
+This will create two directories, lib and bin, together with some CMake cache files. The examples, if enabled, are statically compiled and put into the bin directory, the lib directory contains both libqpu.a and libqpu.so for dynamic and static linking.
 
 ## References
 

--- a/Tests/testMain.cpp
+++ b/Tests/testMain.cpp
@@ -11,12 +11,12 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
 #include <cstdlib>
-#ifdef QPU_MODE
+#ifdef QPULIB_QPU_MODE
 #include "../Lib/Target/Emulator.h"  // MAX_QPUS
 #include "../Lib/VideoCore/RegisterMap.h"
 
 using RegMap = QPULib::RegisterMap;
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE
 
 
 //
@@ -28,7 +28,7 @@ using RegMap = QPULib::RegisterMap;
 	#define POSTFIX_DEBUG ""
 #endif
 
-#ifdef QPU_MODE
+#ifdef QPULIB_QPU_MODE
 //	#pragma message "QPU mode enabled"
 	#define POSTFIX_QPU "-qpu"
 #else
@@ -61,7 +61,7 @@ TEST_CASE("Detect platform scripts should both return the same thing", "[cmdline
 }
 
 
-#ifdef QPU_MODE
+#ifdef QPULIB_QPU_MODE
 
 TEST_CASE("Test correct working of RegisterMap", "[regmap]") {
 
@@ -79,4 +79,4 @@ TEST_CASE("Test correct working of RegisterMap", "[regmap]") {
 	}
 }
 
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE

--- a/Tools/detectPlatform.cpp
+++ b/Tools/detectPlatform.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-#ifdef QPU_MODE
+#ifdef QPULIB_QPU_MODE
 	// Show hardware revision code
 	int mb = getMailbox();	
 	unsigned revision = get_version(mb);
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
 	} else {
 		printf("You can see more if you use sudo\n");
   }
-#endif  // QPU_MODE
+#endif  // QPULIB_QPU_MODE
 
 	return 0;
 }


### PR DESCRIPTION
These two commits add support for building using the cmake build system. The system creates a config file (qpulib_config.h) which defines the preprocessor symbols. The README.md has been updated to include a section on how to compile this project using cmake.